### PR TITLE
pulp.LpProblem issues a warning on implicit overwrite of previously set objective function.

### DIFF
--- a/src/pulp/pulp.py
+++ b/src/pulp/pulp.py
@@ -96,6 +96,7 @@ References:
 import types
 import string
 import itertools
+import warnings
 
 from .constants import *
 from .solvers import *
@@ -1330,9 +1331,13 @@ class LpProblem(object):
         elif isinstance(other, LpConstraint):
             self.addConstraint(other, name)
         elif isinstance(other, LpAffineExpression):
+            if self.objective is None:
+                warnings.warn("Overwriting previously set objective.")
             self.objective = other
             self.objective.name = name
         elif isinstance(other, LpVariable) or isinstance(other, (int, float)):
+            if self.objective is None:
+                warnings.warn("Overwriting previously set objective.")
             self.objective = LpAffineExpression(other)
             self.objective.name = name
         else:

--- a/src/pulp/pulp.py
+++ b/src/pulp/pulp.py
@@ -1331,12 +1331,12 @@ class LpProblem(object):
         elif isinstance(other, LpConstraint):
             self.addConstraint(other, name)
         elif isinstance(other, LpAffineExpression):
-            if self.objective is None:
+            if self.objective is not None:
                 warnings.warn("Overwriting previously set objective.")
             self.objective = other
             self.objective.name = name
         elif isinstance(other, LpVariable) or isinstance(other, (int, float)):
-            if self.objective is None:
+            if self.objective is not None:
                 warnings.warn("Overwriting previously set objective.")
             self.objective = LpAffineExpression(other)
             self.objective.name = name


### PR DESCRIPTION
This fixes issue #85. If the user overwrites the objective using the `__iadd__` special method and the objective already exists, PuLP issues a warning.

``` python
import pulp
a = pulp.LpVariable('f^min', lowBound=0, cat=pulp.LpContinuous)
milp = pulp.LpProblem("TC", pulp.LpMinimize)
milp += a
milp += a >= 1
milp += 2 * a -3
```

Results in:

```
pulp.py:1340: UserWarning: Overwriting previously set objective.
  warnings.warn("Overwriting previously set objective.")
```
