### PR TITLE
Remove pyparsing version check from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,6 @@ version_dict = {}
 exec(open('src/pulp/constants.py').read(), version_dict)
 VERSION = version_dict['VERSION']
 
-#hack because pyparsing made version 2 python 3 specific
-if sys.version_info[0] <= 2:
-    pyparsing_ver = 'pyparsing<=1.9.9'
-else:
-    pyparsing_ver = 'pyparsing>=2.0.0'
-
 setup(name="PuLP",
       version=VERSION,
       description="""
@@ -68,7 +62,7 @@ problems.
                       'pulp.solverdir.cbc.win.64' : ['*','*.*'],
                       'pulp.solverdir.cbc.osx.64' : ['*','*.*'],
                       },
-      install_requires = [pyparsing_ver],
+      install_requires = ['pyparsing>=2.0.1'],
       entry_points = ("""
       [console_scripts]
       pulptest = pulp:pulpTestAll


### PR DESCRIPTION
Variation of:
https://github.com/coin-or/pulp/pull/100

new versions of pyparsing (>=2.0.1) work with python 2.x and 3.x
http://pyparsing.wikispaces.com/News