### PR TITLE
Added exception handling for GUROBI_CMD readsol()

### DIFF
--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -2006,11 +2006,12 @@ class GUROBI_CMD(LpSolver_CMD):
             slacks = {}
             values = {}
             reducedCosts = {}
-            try:
-                name, value  = line.split()
-                values[name] = float(value)
-            except ValueError:
-                pass
+            for line in my_file:
+                try:
+                    name, value  = line.split()
+                    values[name] = float(value)
+                except ValueError:
+                    pass
         return status, values, reducedCosts, shadowPrices, slacks
 
 #get the glpk name in global scope

--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -2006,9 +2006,11 @@ class GUROBI_CMD(LpSolver_CMD):
             slacks = {}
             values = {}
             reducedCosts = {}
-            for line in my_file:
-                    name, value  = line.split()
-                    values[name] = float(value)
+            try:
+                name, value  = line.split()
+                values[name] = float(value)
+            except ValueError:
+                pass
         return status, values, reducedCosts, shadowPrices, slacks
 
 #get the glpk name in global scope


### PR DESCRIPTION
During  `pulp.pulpTestAll()`, `self.readsol(tmpSol)` in `class GUROBI_CMD` encounters a `ValueError: too many values to unpack (expected 2)` which causes the test to fail.