### PR TITLE
Added exception handling to counteract CPLEX 12.6.3.0 '_dummy'

### DIFF
--- a/src/pulp/pulp.py
+++ b/src/pulp/pulp.py
@@ -1583,16 +1583,22 @@ class LpProblem(object):
 
     def assignConsPi(self, values):
         for name in values:
-            self.constraints[name].pi = values[name]
+            try:
+                self.constraints[name].pi = values[name]
+            except KeyError:
+                pass
 
     def assignConsSlack(self, values, activity=False):
         for name in values:
-            if activity:
-                #reports the activitynot the slack
-                self.constraints[name].slack = -1 * (
-                        self.constraints[name].constant + float(values[name]))
-            else:
-                self.constraints[name].slack = float(values[name])
+            try:
+                if activity:
+                    #reports the activitynot the slack
+                    self.constraints[name].slack = -1 * (
+                            self.constraints[name].constant + float(values[name]))
+                else:
+                    self.constraints[name].slack = float(values[name])
+            except KeyError:
+                pass
 
     def get_dummyVar(self):
         if self.dummyVar is None:


### PR DESCRIPTION
Added exception handler for the situations where CPLEX calls `assignConsPi(self,values)` and `assignConsSlack(self,values)` with `values` that contain `_dummy`