### PR TITLE
Use thread-safe subprocess32 on Py2

### DIFF
--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -31,7 +31,6 @@ the current version
 """
 
 import os
-import subprocess
 import sys
 from time import clock
 try:
@@ -46,6 +45,16 @@ from .constants import *
 
 import logging
 log = logging.getLogger(__name__)
+
+if os.name == "posix" and sys.version_info[0] < 3:
+    try:
+        import subprocess32 as subprocess
+    except ImportError:
+        log.debug("Thread-safe subprocess32 module not found! "
+                  "Using unsafe built-in subprocess module instead.")
+        import subprocess
+else:
+    import subprocess
 
 class PulpSolverError(PulpError):
     """


### PR DESCRIPTION
https://github.com/google/python-subprocess32 is a backport of Python 3 `subprocess` which is thread-safe on POSIX.

[FFC](https://bitbucket.org/fenics-project/ffc/) (which depends on [COFFEE](https://github.com/coneoproject/COFFEE) which in turn depends on PuLP) is often being run on Infiniband clusters where Python2 `subprocess` implementation is known to randomly segfault. This is the problem related to thread-safety.