### PR TITLE
bug-fix: white space in path to cbc solver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 - pypy
 before_install:
 - sudo apt-get update -qq
-- sudo apt-get install -qq glpk
+- sudo apt-get install -qq glpk-utils
 install:
 - pip install .
 script: pulptest

--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -1416,8 +1416,10 @@ class COIN_CMD(LpSolver_CMD):
         else:
             pipe = open(os.devnull, 'w')
         log.debug(self.path + cmds)
-        cbc = subprocess.Popen((self.path + cmds).split(), stdout = pipe,
-                             stderr = pipe)
+        args = []
+        args.append(self.path)
+        args.extend(cmds[1:].split())
+        cbc = subprocess.Popen(args, stdout = pipe, stderr = pipe)
         if cbc.wait() != 0:
             raise PulpSolverError("Pulp: Error while trying to execute " +  \
                                     self.path)


### PR DESCRIPTION
Without this fix, pulp currently crashes in the case there is a space in the path to the CBC solver.