### PR TITLE
Fixed issue where negative zero's result in invalid cplex files

### DIFF
--- a/src/pulp/pulp.py
+++ b/src/pulp/pulp.py
@@ -664,7 +664,8 @@ class LpAffineExpression(_DICT_TYPE):
             if val == 1:
                 term = "%s %s" %(sign, v.name)
             else:
-                term = "%s %.12g %s" % (sign, val, v.name)
+                #adding zero to val to remove instances of negative zero
+                term = "%s %.12g %s" % (sign, val + 0, v.name)
 
             if self._count_characters(line) + len(term) > LpCplexLPLineSize:
                 result += ["".join(line)]


### PR DESCRIPTION
Encountered an edge case where pulp will write a negative zero into a cplex file, which results in an error from glpsol. The odd fix is based on this workaround from stack overflow:

https://stackoverflow.com/questions/11010683/how-to-have-negative-zero-always-formatted-as-positive-zero-in-a-python-string/36604981