### PR TITLE
Feature: Add timeout option for CBC solver

### DIFF
--- a/src/pulp/pulp.py
+++ b/src/pulp/pulp.py
@@ -1668,7 +1668,7 @@ class LpProblem(object):
         return status
 
     def sequentialSolve(self, objectives, absoluteTols = None,
-                        relativeTols = None, solver = None, debug = False, timeout = None):
+                        relativeTols = None, solver = None, debug = False, processTimeout = None):
         """
         Solve the given Lp problem with several objective functions.
 
@@ -1680,7 +1680,7 @@ class LpProblem(object):
            the constraints should be +ve for a minimise objective
         :param relativeTols: the list of relative tolerances applied to the constraints
         :param solver: the specific solver to be used, defaults to the default solver.
-        :param timeout: Timeout (in second) passed to Popen.wait() (for CBC solver only)
+        :param processTimeout: Timeout (in second) passed to Popen.wait() (for CBC solver only)
 
         """
         #TODO Add a penalty variable to make problems elastic
@@ -1698,7 +1698,7 @@ class LpProblem(object):
         for i,(obj,absol,rel) in enumerate(zip(objectives,
                                                absoluteTols, relativeTols)):
             self.setObjective(obj)
-            status = solver.actualSolve(self, timeout=timeout)
+            status = solver.actualSolve(self, processTimeout=processTimeout)
             statuses.append(status)
             if debug: self.writeLP("%sSequence.lp"%i)
             if self.sense == LpMinimize:

--- a/src/pulp/pulp.py
+++ b/src/pulp/pulp.py
@@ -1668,7 +1668,7 @@ class LpProblem(object):
         return status
 
     def sequentialSolve(self, objectives, absoluteTols = None,
-                        relativeTols = None, solver = None, debug = False):
+                        relativeTols = None, solver = None, debug = False, timeout = None):
         """
         Solve the given Lp problem with several objective functions.
 
@@ -1680,6 +1680,7 @@ class LpProblem(object):
            the constraints should be +ve for a minimise objective
         :param relativeTols: the list of relative tolerances applied to the constraints
         :param solver: the specific solver to be used, defaults to the default solver.
+        :param timeout: Timeout (in second) passed to Popen.wait() (for CBC solver only)
 
         """
         #TODO Add a penalty variable to make problems elastic
@@ -1697,7 +1698,7 @@ class LpProblem(object):
         for i,(obj,absol,rel) in enumerate(zip(objectives,
                                                absoluteTols, relativeTols)):
             self.setObjective(obj)
-            status = solver.actualSolve(self)
+            status = solver.actualSolve(self, timeout=timeout)
             statuses.append(status)
             if debug: self.writeLP("%sSequence.lp"%i)
             if self.sense == LpMinimize:

--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -1365,7 +1365,7 @@ class COIN_CMD(LpSolver_CMD):
         """True if the solver is available"""
         return self.executable(self.path)
 
-    def solve_CBC(self, lp, use_mps=True):
+    def solve_CBC(self, lp, use_mps=True, timeout=None):
         """Solve a MIP problem using CBC"""
         if not self.executable(self.path):
             raise PulpSolverError("Pulp: cannot execute %s cwd: %s"%(self.path,
@@ -1420,7 +1420,11 @@ class COIN_CMD(LpSolver_CMD):
         args.append(self.path)
         args.extend(cmds[1:].split())
         cbc = subprocess.Popen(args, stdout = pipe, stderr = pipe)
-        if cbc.wait() != 0:
+
+        if timeout is not None and sys.version_info < (3, 3):
+            warnings.warn('Pulp: Subprocess timeout is not available in python < 3.3. Solver will run indefinitely.')
+
+        if (cbc.wait(timeout) if sys.version_info >= (3, 3) else cb.wait()) != 0:
             raise PulpSolverError("Pulp: Error while trying to execute " +  \
                                     self.path)
         if not os.path.exists(tmpSol):

--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -1365,7 +1365,7 @@ class COIN_CMD(LpSolver_CMD):
         """True if the solver is available"""
         return self.executable(self.path)
 
-    def solve_CBC(self, lp, use_mps=True, timeout=None):
+    def solve_CBC(self, lp, use_mps=True, processTimeout=None):
         """Solve a MIP problem using CBC"""
         if not self.executable(self.path):
             raise PulpSolverError("Pulp: cannot execute %s cwd: %s"%(self.path,
@@ -1421,10 +1421,10 @@ class COIN_CMD(LpSolver_CMD):
         args.extend(cmds[1:].split())
         cbc = subprocess.Popen(args, stdout = pipe, stderr = pipe)
 
-        if timeout is not None and sys.version_info < (3, 3):
+        if processTimeout is not None and sys.version_info < (3, 3):
             warnings.warn('Pulp: Subprocess timeout is not available in python < 3.3. Solver will run indefinitely.')
 
-        if (cbc.wait(timeout) if sys.version_info >= (3, 3) else cbc.wait()) != 0:
+        if (cbc.wait(processTimeout) if sys.version_info >= (3, 3) else cbc.wait()) != 0:
             raise PulpSolverError("Pulp: Error while trying to execute " +  \
                                     self.path)
         if not os.path.exists(tmpSol):

--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -1424,7 +1424,7 @@ class COIN_CMD(LpSolver_CMD):
         if timeout is not None and sys.version_info < (3, 3):
             warnings.warn('Pulp: Subprocess timeout is not available in python < 3.3. Solver will run indefinitely.')
 
-        if (cbc.wait(timeout) if sys.version_info >= (3, 3) else cb.wait()) != 0:
+        if (cbc.wait(timeout) if sys.version_info >= (3, 3) else cbc.wait()) != 0:
             raise PulpSolverError("Pulp: Error while trying to execute " +  \
                                     self.path)
         if not os.path.exists(tmpSol):

--- a/src/pulp/tests.py
+++ b/src/pulp/tests.py
@@ -1,6 +1,8 @@
 """
 Tests for pulp
 """
+from subprocess import TimeoutExpired
+from sys import version_info
 from .pulp import *
 
 def dumpTestProblem(prob):
@@ -497,6 +499,28 @@ def pulpTest100(solver):
                   sol = {x:0, y:1},
                   status = status)
 
+def pulpTest101(solver):
+    """
+    Test the timing out of sequentialSolve()
+    """
+    # set up a cubic feasible region
+    prob = LpProblem("test101", LpMinimize)
+    x = LpVariable("x", 0, 1)
+    y = LpVariable("y", 0, 1)
+    z = LpVariable("z", 0, 1)
+
+    obj1 = x+0*y+0*z
+    obj2 = 0*x-1*y+0*z
+    prob += x <= 1, "c1"
+
+    if solver.__class__ in [PULP_CBC_CMD] and version_info >= (3, 3):
+        print("\t Testing CBC Timeout (python >= 3.3)")
+        try:
+            status = prob.sequentialSolve([obj1,obj2], solver = solver, timeout=0)
+            assert False, 'This should not have been executed'
+        except TimeoutExpired:
+            pass
+
 def pulpTest110(solver):
     """
     Test the ability to use fractional constraints
@@ -614,6 +638,7 @@ def pulpTestSolver(solver, msg = 0):
             pulpTest080,
             pulpTest090,
             pulpTest100,
+            pulpTest101,
             pulpTest110,
             pulpTest120, pulpTest121, pulpTest122, pulpTest123
             ]

--- a/src/pulp/tests.py
+++ b/src/pulp/tests.py
@@ -516,7 +516,7 @@ def pulpTest101(solver):
         print("\t Testing CBC Timeout (python >= 3.3)")
         from subprocess import TimeoutExpired
         try:
-            status = prob.sequentialSolve([obj1,obj2], solver = solver, timeout=0)
+            status = prob.sequentialSolve([obj1,obj2], solver = solver, processTimeout=0)
             assert False, 'This should not have been executed'
         except TimeoutExpired:
             pass

--- a/src/pulp/tests.py
+++ b/src/pulp/tests.py
@@ -1,7 +1,6 @@
 """
 Tests for pulp
 """
-from subprocess import TimeoutExpired
 from sys import version_info
 from .pulp import *
 
@@ -515,6 +514,7 @@ def pulpTest101(solver):
 
     if solver.__class__ in [PULP_CBC_CMD] and version_info >= (3, 3):
         print("\t Testing CBC Timeout (python >= 3.3)")
+        from subprocess import TimeoutExpired
         try:
             status = prob.sequentialSolve([obj1,obj2], solver = solver, timeout=0)
             assert False, 'This should not have been executed'


### PR DESCRIPTION
Hi There,

First of all thanks a lot for Pulp, this is very useful and powerful piece of software.

Full disclaimer: This is my first (real) OOS pull-request, so please point out anything I might be doing wrong.

# What this pull request does

Add a `timeout` option for the CBC solver, which relies on `Popen.wait(timeout)`.

# Why

While running `pulp` on a production server (Apache), I found several instances of leftover `cbc` threads which have been running for days. I suspect Apache killed the main Python `CGI` thread but somehow left the `cbc` thread behind. Generally speaking, for problems of unknown size, I think some user might find it convenient to be able to use a timeout as a measure of (immediate) feasibility of a problem.

# Describe the approach

I piggybacked on `Popen.wait(timeout)` which takes an optional `timeout` argument since `3.3` and raises a `TimeoutExpired` exception if exceeding the provided timeout. I simply forwarded the `timeout` keyword argument from high level function (`solve()`, `actualSolve()` and `sequentialSolve()`, for functions not already using keyword argument unpacking) down to `Popen.wait()`. I made sure to make the code `2.7` compatible (obviously they won't be able to use this feature, and will get a warning if they do). I also added a test. I chose not to catch the `TimeoutExpired` and let the user deal with it, rather than wrap it in some specific Pulp exception, but that behaviour can be changed very easily.

I hope you merge it,

Best, Bertrand