### PR TITLE
added property for LpElement.cat

### DIFF
--- a/src/pulp/pulp.py
+++ b/src/pulp/pulp.py
@@ -257,7 +257,7 @@ class LpVariable(LpElement):
         LpElement.__init__(self,name)
         self.lowBound = lowBound
         self.upBound = upBound
-        self.cat = cat
+        self.__cat = cat
         self.varValue = None
         self.dj = None
         self.init = 0
@@ -266,7 +266,7 @@ class LpVariable(LpElement):
         if cat == LpBinary:
             self.lowBound = 0
             self.upBound = 1
-            self.cat = LpInteger
+            self.__cat = LpInteger
         if e:
             self.add_expression(e)
 
@@ -371,6 +371,20 @@ class LpVariable(LpElement):
         self.upBound = up
         self.modified = True
 
+    def setCat(self, cat):
+        if cat == LpBinary:
+            self.__cat = LpInteger
+            self.lowBound = 0
+            self.upBound = 1
+        else:
+            self.__cat = cat
+        self.modified = True
+    
+    def getCat(self):
+        return self.__cat
+
+    cat = property(fget = getCat,fset = setCat)
+    
     def positive(self):
         self.bounds(0, None)
 


### PR DESCRIPTION
Hello,
a problem I've recently experienced is the following. Changing the category of a variable to `LpBinary` is equivalent to changing it to `LpContinuous`.     
Indeed, only when calling the constructor the check `if cat == LpBinary` is made. After, it is not made and in `solvers.py` since the test `if var.cat == LpInteger ` will fail it will be considered of type `LpContinuous` by default.   
Consider for instance the following example.

    import pulp

    prob = pulp.LpProblem("prob", pulp.LpMinimize)

    x = pulp.LpVariable("x", lowBound=0, upBound=1, cat=pulp.LpContinuous)

    prob+= x
    prob+= x >= 0.5

    prob.solve()
    print("obj -> {}".format(pulp.value(prob.objective))) # obj -> 0.5

    # to Integer 

    x.cat = pulp.LpInteger
    print(x.isInteger()) #True
    prob.solve()
    print("obj -> {}".format(pulp.value(prob.objective)))  # obj -> 1.0

    # to Binary

    x.cat = pulp.LpBinary
    print(x.isBinary()) # False as the check isBinary() will fail
    prob.solve()
    print("obj -> {}".format(pulp.value(prob.objective))) # obj -> 0.5


As I usually change the type of the variables, and I recently had unexpected behaviour I think it may be useful also for the users to add this possibility instead of having to do something like:

    x.cat = pulp.LpInteger
    x.bounds(0,1)
