### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/src/pulp/pulp.py
+++ b/src/pulp/pulp.py
@@ -135,7 +135,7 @@ def setConfigInformation(**keywords):
     """
     #TODO: extend if we ever add another section in the config file
     #read the old configuration
-    config = ConfigParser.SafeConfigParser()
+    config = ConfigParser.ConfigParser()
     config.read(config_filename)
     #set the new keys
     for (key,val) in keywords.items():

--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -67,7 +67,7 @@ class PulpSolverError(PulpError):
 def initialize(filename, operating_system='linux', arch='64'):
     """ reads the configuration file to initialise the module"""
     here = os.path.dirname(filename)
-    config = configparser.SafeConfigParser({'here':here,
+    config = configparser.ConfigParser({'here':here,
         'os':operating_system, 'arch':arch})
     config.read(filename)
 


### PR DESCRIPTION
Here is the message :
DeprecationWarning: The SafeConfigParser class has been renamed to
ConfigParser in Python 3.2. This alias will be removed in future
versions. Use ConfigParser directly instead.

Fix #145 