### PR TITLE
Change the logic of collecting Gurobi variables to bulk fetching

### DIFF
--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -1827,25 +1827,31 @@ class GUROBI(LpSolver):
                                    GRB.NUMERIC: LpStatusNotSolved,
                                    }
             #populate pulp solution values
-            for var in lp.variables():
-                try:
-                    var.varValue = var.solverVar.X
-                except (gurobipy.GurobiError, AttributeError):
-                    pass
-                try:
-                    var.dj = var.solverVar.RC
-                except (gurobipy.GurobiError, AttributeError):
-                    pass
+            try:
+                for var, value in zip(lp.variables(), model.getAttr(GRB.Attr.X, model.getVars())):
+                    var.varValue = value
+            except (gurobipy.GurobiError, AttributeError):
+                pass
+
+            try:
+                for var, value in zip(lp.variables(), model.getAttr(GRB.Attr.RC, model.getVars())):
+                    var.dj = value
+            except (gurobipy.GurobiError, AttributeError):
+                pass
+
             #put pi and slack variables against the constraints
-            for constr in lp.constraints.values():
-                try:
-                    constr.pi = constr.solverConstraint.Pi
-                except (gurobipy.GurobiError, AttributeError):
-                    pass
-                try:
-                    constr.slack = constr.solverConstraint.Slack
-                except(gurobipy.GurobiError, AttributeError):
-                    pass
+            try:
+                for constr, value in zip(lp.constraints.values(), model.getAttr(GRB.Pi, model.getConstrs())):
+                    constr.pi = value
+            except (gurobipy.GurobiError, AttributeError):
+                pass
+
+            try:
+                for constr, value in zip(lp.constraints.values(), model.getAttr(GRB.Slack, model.getConstrs())):
+                    constr.slack = value
+            except (gurobipy.GurobiError, AttributeError):
+                pass
+
             if self.msg:
                 print("Gurobi status=", solutionStatus)
             lp.resolveOK = True


### PR DESCRIPTION
Gurobi 8 started to use HTTP protocal for data transfer, if we call the library to get the value of the variables like this: 

```python
for var in lp.variables(): 
    var.varValue = var.solverVar.X
```
Gurobipy will send out an HTTP request to the gurobi server for every variables. If we have a very large number of variables, `findSolutionValues` can be pretty expensive and slow.

Luckily, Gurobipy also provides a way to bulk fetch all the variables together in a single HTTP request by doing

```python
m.getAttr(GRB.Attr.X, m.getVars())
```

which is a lot faster.