### PR TITLE
python3.8 (fixes gh-192)

### DIFF
--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -32,7 +32,10 @@ the current version
 
 import os
 import sys
-from time import clock
+try:
+    from time import clock
+except ImportError:
+    from time import perf_counter as clock
 from uuid import uuid4
 try:
     import configparser


### PR DESCRIPTION
Should fix #192 
I ran into this problem in a dev environment where I am using python3.8 alpha:
```
   from time import clock
E   ImportError: cannot import name 'clock' from 'time' (unknown location)

/opt/cpython-master/lib/python3.8/site-packages/pulp/solvers.py:35: ImportError
```