### PR TITLE
Update solvers.py for solve(GUROBI()) and solve(CPLEX(mip = False))

### DIFF
--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -1191,7 +1191,7 @@ else:
                 lp.assignVarsVals(variablevalues)
                 constraintslackvalues = dict(zip(con_names, lp.solverModel.solution.get_linear_slacks(con_names)))
                 lp.assignConsSlack(constraintslackvalues)
-                if lp.solverModel.get_problem_type == cplex.Cplex.problem_type.LP:
+                if lp.solverModel.get_problem_type() == cplex.Cplex.problem_type.LP:
                     variabledjvalues = dict(zip(var_names, lp.solverModel.solution.get_reduced_costs(var_names)))
                     lp.assignVarsDj(variabledjvalues)
                     constraintpivalues = dict(zip(con_names, lp.solverModel.solution.get_dual_values(con_names)))

--- a/src/pulp/solvers.py
+++ b/src/pulp/solvers.py
@@ -1841,13 +1841,13 @@ class GUROBI(LpSolver):
 
             #put pi and slack variables against the constraints
             try:
-                for constr, value in zip(lp.constraints.values(), model.getAttr(GRB.Pi, model.getConstrs())):
+                for constr, value in zip(lp.constraints.values(), model.getAttr(GRB.Attr.Pi, model.getConstrs())):
                     constr.pi = value
             except (gurobipy.GurobiError, AttributeError):
                 pass
 
             try:
-                for constr, value in zip(lp.constraints.values(), model.getAttr(GRB.Slack, model.getConstrs())):
+                for constr, value in zip(lp.constraints.values(), model.getAttr(GRB.Attr.Slack, model.getConstrs())):
                     constr.slack = value
             except (gurobipy.GurobiError, AttributeError):
                 pass


### PR DESCRIPTION
GUROBI: In python3.7 and gurobi-python37, the shadowPrice(or Pi) in gurobipy.GRB is not GRB.Pi but GRB.Attr.Pi. Same as slack. Other earlier versions have not been tested.

CPLEX: In the class CPLEX_PY, before "put pi and slack variables", "lp.solverModel.get_problem_type" is a function, so it should be "lp.solverModel.get_problem_type()". And we can use "prob.solve(CPLEX(mip = False))" when we know the prob is a LP problem and we want to konw the Pi and slack.