### PR TITLE
Also run unittests for Python versions 3.7 and newer in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,47 @@
 language: python
-python:
-- '2.6'
-- '2.7'
-- '3.3'
-- '3.4'
-- '3.5'
-- '3.6'
-- '3.7'
-- '3.7-dev'
-- '3.8-dev'
-- 'nightly'
-- 'pypy'
-- 'pypy3.5'
+matrix:
+  include:
+    # Ubuntu 14.04 LTS (Trusty Tahr)
+    - dist: trusty
+      python: 2.6
+    - dist: trusty
+      python: 2.7
+    - dist: trusty
+      python: 3.3
+    - dist: trusty
+      python: 3.4
+    - dist: trusty
+      python: pypy
+    # Ubuntu 16.04 LTS (Xenial Xerus)
+    - dist: xenial
+      python: 3.5
+    # Ubuntu 18.04 LTS (Bionic Beaver)
+    - dist: bionic
+      python: 3.6
+    - dist: bionic
+      python: 3.7
+    - dist: bionic
+      python: 3.7-dev
+    - dist: bionic
+      python: 3.8-dev
+    - dist: bionic
+      python: nightly
+    - dist: bionic
+      python: pypy3.5
+
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq glpk-utils
+
 install:
 - pip install .
+
 script: pulptest
+
 before_deploy:
 - sudo apt-get install texlive-latex-extra
 - sudo apt-get install dvipng
+
 deploy:
   provider: pypi
   docs_dir: doc/build/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,12 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-- pypy
+- '3.7'
+- '3.7-dev'
+- '3.8-dev'
+- 'nightly'
+- 'pypy'
+- 'pypy3.5'
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq glpk-utils

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     # Ubuntu 16.04 LTS (Xenial Xerus)
     - dist: xenial
       python: 3.5
+    - dist: xenial
+      python: pypy3.5
     # Ubuntu 18.04 LTS (Bionic Beaver)
     - dist: bionic
       python: 3.6
@@ -26,8 +28,6 @@ matrix:
       python: 3.8-dev
     - dist: bionic
       python: nightly
-    - dist: bionic
-      python: pypy3.5
 
 before_install:
 - sudo apt-get update -qq


### PR DESCRIPTION
In order to catch issues like #192 (library deprecated in Python 3.8) as early as possible the unittests should always be run for all supported Python versions in this library's CI loop. Therefore I propose adding Python versions `3.7`, `3.7-dev`, `3.8-dev` and `nightly` (along with PyPy 3.5) to the Travis CI loop.