### PR TITLE
fix import from collections deprecation warning for python 3.8

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -100,7 +100,11 @@ import warnings
 
 from .constants import *
 from .solvers import *
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    # python 2.7 compatible 
+    from collections import Iterable
 
 import logging
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes this issue when importing pulp

Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working.

shamelessly copied from:
https://github.com/pyparsing/pyparsing/pull/16/commits/cab6d89801635efca99ded91e5a5e1e829f33876

Now pytest doesn't complain anymore.