### PR TITLE
Remove warnings about `time.clock()`

### DIFF
--- a/pulp/solvers.py
+++ b/pulp/solvers.py
@@ -33,9 +33,10 @@ the current version
 import os
 import sys
 try:
-    from time import clock
-except ImportError:
     from time import perf_counter as clock
+except ImportError:
+    from time import clock
+    
 from uuid import uuid4
 try:
     import configparser


### PR DESCRIPTION
Importing the python3.8 correct module first allows to remove the warnings for python 3.7 while keeping compatibility for all versions.