### PR TITLE
Remove the redundant Description variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 from setuptools import setup
 
 readme_name = 'README.rst'
-Description = open(readme_name).read()
+
 
 # License = open('LICENSE').read()
 


### PR DESCRIPTION
It seems as though after having introduced the long_description variable, the removal of Description was missed upon.