### PR TITLE
fix(tests): Import tests correctly for pulpTestAll method

### DIFF
--- a/pulp/__init__.py
+++ b/pulp/__init__.py
@@ -36,6 +36,7 @@ from amply import *
 from .apis import *
 from .utilities import *
 from .constants import *
+from .tests import pulpTestAll
 
 __doc__ = pulp.__doc__
 __version__ = VERSION

--- a/pulp/tests/__init__.py
+++ b/pulp/tests/__init__.py
@@ -1,0 +1,1 @@
+from .run_tests import pulpTestAll

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -607,6 +607,12 @@ class PuLPTest(unittest.TestCase):
         else:
             pulpTestCheck(prob, self.solver, [const.LpStatusUnbounded])
 
+    def test_pulpTestAll(self):
+        """
+        Test the availability of the function pulpTestAll
+        """
+        from pulp import pulpTestAll
+        print("\t Testing the availability of the function pulpTestAll")
 
 def pulpTestCheck(prob, solver, okstatus, sol=None,
                   reducedcosts=None,

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -651,8 +651,8 @@ class PuLPTest(unittest.TestCase):
         """
         Test the availability of the function pulpTestAll
         """
-        from pulp import pulpTestAll
         print("\t Testing the availability of the function pulpTestAll")
+        from pulp import pulpTestAll
 
     def test_export_dict_LP(self):
         prob = LpProblem("test_export_dict_LP", const.LpMinimize)


### PR DESCRIPTION
Hello!
Based on the PR #306 , we should fix the situation:
```python3
>>> import pulp
>>> pulp.pulpTestAll()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'pulp' has no attribute 'pulpTestAll'
```

The reason it failed is based on 2 reasons:
* pulp/tests/\_\_init\_\_.py didn't import the run_tests module
* pulp/\_\_init\_\_.py didn't import the tests package

The modules doesn't share the same name with their packages are [submodules](https://docs.python.org/3/reference/import.html#submodules).
We should import submodules in \_\_init\_\_.py.
* The run_tests module does not share the name `tests` with its package.

So, I got 2 solutions here:
1. Import submodules in pulp/tests/\_\_init\_\_.py:
    * Which is provided in this PR.
    * Consistent with the pulp/\_\_init\_\_.py
    * Easy and less modified.
2. Rename the run_tests.py to tests.py:
    * Still need to import tests in pulp/\_\_init\_\_.py