### PR TITLE
Fix makeDict's behavior

### DIFF
--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -819,7 +819,7 @@ class PuLPTest(unittest.TestCase):
 
     def test_makeDict_behavior(self):
         """
-        Test if the makeDict function is returning the expected value.
+        Test if makeDict is returning the expected value.
         """
         headers = [["A", "B"], ["C", "D"]]
         values = [[1, 2], [3, 4]]
@@ -832,7 +832,7 @@ class PuLPTest(unittest.TestCase):
 
     def test_makeDict_default_value(self):
         """
-        Test if the makeDict function is returning a defaultdict when default is specified.
+        Test if makeDict is returning a default value when specified.
         """
         headers = [["A", "B"], ["C", "D"]]
         values = [[1, 2], [3, 4]]

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -5,6 +5,7 @@ from pulp.constants import PulpError
 from pulp.apis import *
 from pulp import LpVariable, LpProblem, lpSum, LpConstraintVar, LpFractionConstraint
 from pulp import constants as const
+from pulp.utilities import makeDict
 import unittest
 
 
@@ -815,6 +816,24 @@ class PuLPTest(unittest.TestCase):
                 raise PulpError("Test failed for solver: {}".format(self.solver))
             if not os.path.getsize(logFilename):
                 raise PulpError("Test failed for solver: {}".format(self.solver))
+
+    def test_makeDict(self):
+        """
+        Test if the makeDict function is behaving correctly.
+        """
+        headers = [["A", "B"], ["C", "D"]]
+        values = [[1, 2], [3, 4]]
+        dict_with_default = makeDict(headers, values, default=0)
+        dict_without_default = makeDict(headers, values)
+
+        print("\t Testing makeDict behavior")
+        # Check if a default value is passed, and if a KeyError is raised
+        assert dict_with_default["X"]["Y"] == 0
+        try:
+            z = dict_without_default["X"]["Y"]
+            raise PulpError("Test for makeDict failed")
+        except KeyError:
+            pass
 
 
 def pulpTestCheck(prob, solver, okstatus, sol=None,

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -826,9 +826,9 @@ class PuLPTest(unittest.TestCase):
         target = {"A": {"C": 1, "D": 2}, "B": {"C": 3, "D": 4}}
         dict_with_default = makeDict(headers, values, default=0)
         dict_without_default = makeDict(headers, values)
-        print("\t Testing makeDict behavior")
-        assert dict_with_default == target
-        assert dict_without_default == target
+        print("\t Testing makeDict general behavior")
+        self.assertEqual(dict_with_default, target)
+        self.assertEqual(dict_without_default, target)
 
     def test_makeDict_default_value(self):
         """
@@ -838,15 +838,12 @@ class PuLPTest(unittest.TestCase):
         values = [[1, 2], [3, 4]]
         dict_with_default = makeDict(headers, values, default=0)
         dict_without_default = makeDict(headers, values)
-
         print("\t Testing makeDict default value behavior")
-        # Check if a default value is passed, and if a KeyError is raised
-        assert dict_with_default["X"]["Y"] == 0
-        try:
-            z = dict_without_default["X"]["Y"]
-            raise PulpError("Test for makeDict default value failed")
-        except KeyError:
-            pass
+        # Check if a default value is passed
+        self.assertEqual(dict_with_default["X"]["Y"], 0)
+        # Check if a KeyError is raised
+        _func = lambda: dict_without_default["X"]["Y"]
+        self.assertRaises(KeyError, _func)
 
 
 def pulpTestCheck(prob, solver, okstatus, sol=None,

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -817,21 +817,34 @@ class PuLPTest(unittest.TestCase):
             if not os.path.getsize(logFilename):
                 raise PulpError("Test failed for solver: {}".format(self.solver))
 
-    def test_makeDict(self):
+    def test_makeDict_behavior(self):
         """
-        Test if the makeDict function is behaving correctly.
+        Test if the makeDict funcion is behaving correctly.
+        """
+        headers = [["A", "B"], ["C", "D"]]
+        values = [[1, 2], [3, 4]]
+        target = {"A": {"C": 1, "D": 2}, "B": {"C": 3, "D": 4}}
+        dict_with_default = makeDict(headers, values, default=0)
+        dict_without_default = makeDict(headers, values)
+        print("\t Testing makeDict behavior")
+        assert dict_with_default == target
+        assert dict_without_default == target
+
+    def test_makeDict_default_value(self):
+        """
+        Test if the makeDict function is returning a defaultdict when default is specified.
         """
         headers = [["A", "B"], ["C", "D"]]
         values = [[1, 2], [3, 4]]
         dict_with_default = makeDict(headers, values, default=0)
         dict_without_default = makeDict(headers, values)
 
-        print("\t Testing makeDict behavior")
+        print("\t Testing makeDict default value behavior")
         # Check if a default value is passed, and if a KeyError is raised
         assert dict_with_default["X"]["Y"] == 0
         try:
             z = dict_without_default["X"]["Y"]
-            raise PulpError("Test for makeDict failed")
+            raise PulpError("Test for makeDict default value failed")
         except KeyError:
             pass
 

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -819,7 +819,7 @@ class PuLPTest(unittest.TestCase):
 
     def test_makeDict_behavior(self):
         """
-        Test if the makeDict funcion is behaving correctly.
+        Test if the makeDict function is returning the expected value.
         """
         headers = [["A", "B"], ["C", "D"]]
         values = [[1, 2], [3, 4]]

--- a/pulp/utilities.py
+++ b/pulp/utilities.py
@@ -156,7 +156,7 @@ def __makeDict(headers, array, default=None):
     else:
         for i, h in enumerate(headers[0]):
             result[h], defaultvalue = __makeDict(headers[1:], array[i], default)
-    if default is None:
+    if not default is None:
         f = lambda: defaultvalue
         defresult = collections.defaultdict(f)
         defresult.update(result)

--- a/pulp/utilities.py
+++ b/pulp/utilities.py
@@ -156,7 +156,7 @@ def __makeDict(headers, array, default=None):
     else:
         for i, h in enumerate(headers[0]):
             result[h], defaultvalue = __makeDict(headers[1:], array[i], default)
-    if not default is None:
+    if default is not None:
         f = lambda: defaultvalue
         defresult = collections.defaultdict(f)
         defresult.update(result)


### PR DESCRIPTION
Change the condition on the recursive function `__makeDict` so that a defaultdict is returned when `default` is specified.

Also, add a test `test_makeDict` on `pulp/tests/test_pulp.py` that creates two dictionaries with the same headers and values, but one with a default value and the other without it. The test passes if `dict_with_default` returns the default value when we try to access a non-existent key and if `dict_without_default` raises a KeyError when we try to access the same key.