### PR TITLE
Example in documentation, b to a2 to avoid glpk error symbol 'b' in wrong position 

### DIFF
--- a/doc/source/guides/how_to_configure_solvers.rst
+++ b/doc/source/guides/how_to_configure_solvers.rst
@@ -72,7 +72,7 @@ Imagine using the ``CPLEX_CMD`` solver, the first one is really simple:
     model = pl.LpProblem("Example", pl.LpMinimize)
     solver = pl.CPLEX_CMD(path=path_to_cplex)
     _var = pl.LpVariable('a')
-    _var2 = pl.LpVariable('b')
+    _var2 = pl.LpVariable('a2')
     model += _var + _var2 == 1 
     result = model.solve(solver)
 
@@ -90,7 +90,7 @@ Once we have done that, we just do something very similar to the previous exampl
     model = pl.LpProblem("Example", pl.LpMinimize)
     solver = pl.CPLEX_CMD()
     _var = pl.LpVariable('a')
-    _var2 = pl.LpVariable('b')
+    _var2 = pl.LpVariable('a2')
     model += _var + _var2 == 1 
     result = model.solve(solver)
 
@@ -151,7 +151,7 @@ By default, PuLP does not keep the intermediary files (the \*.mps, \*.lp, \*.mst
     import pulp as pl
     model = pl.LpProblem("Example", pl.LpMinimize)
     _var = pl.LpVariable('a')
-    _var2 = pl.LpVariable('b')
+    _var2 = pl.LpVariable('a2')
     model += _var + _var2 == 1 
     solver = pl.PULP_CBC_CMD()
     result = model.solve(solver)
@@ -163,7 +163,7 @@ Another option, is passing the argument `KeepFiles=True` to the solver. With thi
     import pulp as pl
     model = pl.LpProblem("Example", pl.LpMinimize)
     _var = pl.LpVariable('a')
-    _var2 = pl.LpVariable('b')
+    _var2 = pl.LpVariable('a2')
     model += _var + _var2 == 1 
     solver = pl.PULP_CBC_CMD(keepFiles=True)
     result = model.solve(solver)
@@ -175,7 +175,7 @@ Finally, one can manually edit the tmpDir attribute of the solver object before 
     import pulp as pl
     model = pl.LpProblem("Example", pl.LpMinimize)
     _var = pl.LpVariable('a')
-    _var2 = pl.LpVariable('b')
+    _var2 = pl.LpVariable('a2')
     model += _var + _var2 == 1 
     solver = pl.PULP_CBC_CMD()
     solver.tmpDir = 'PUT_SOME_ALTERNATIVE_PATH_HERE'


### PR DESCRIPTION
If I followed the original example

```
import pulp as pl
model = pl.LpProblem("Example", pl.LpMinimize)
solver = pl.GLPK_CMD()
_var = pl.LpVariable('a')
_var2 = pl.LpVariable('b')
model += _var + _var2 == 1
result = model.solve(solver)
```

and when I used glpk I got this error 

```
51e9991f96fa4fca84d1c57df2ba6fd5-pulp.lp:9: symbol 'b' in wrong position
CPLEX LP file processing error
Traceback (most recent call last):
  File "first.py", line 7, in <module>
    result = model.solve(solver)
    ..., line 93, in actualSolve
    raise PulpSolverError("PuLP: Error while executing "+self.path)
pulp.apis.core.PulpSolverError: PuLP: Error while executing glpsol
```

I found the explanation in this mail list.

> I did read it before posting and in my version (4.11) it is made
> explicit that  "[B|b]ounds" and "bound" are synonymous

https://lists.gnu.org/archive/html/help-glpk/2007-04/msg00026.html

After I changed the letter `b` to another one, I could use the example.