### PR TITLE
Issue 104 allow non dummy vars

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -429,7 +429,10 @@ class LpVariable(LpElement):
             return 0
 
     def valid(self, eps):
-        if self.varValue is None: return False
+        if self.name == '__dummy' and self.varValue is None:
+            return True
+        if self.varValue is None:
+            return False
         if self.upBound is not None and self.varValue > self.upBound + eps:
             return False
         if self.lowBound is not None and self.varValue < self.lowBound - eps:

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -931,6 +931,44 @@ class PuLPTest(unittest.TestCase):
         print("\t Testing reading MPS files - binary variable, no constraint names")
         self.assertDictEqual(_dict1, _dict2)
 
+    def test_unset_objective_value__is_valid(self):
+        """Given a valid problem that does not have
+        and driver in the objective function to direct it's minimisation
+        because the variable is multiplied by zero, assert that it
+        is still categorised as valid.
+        """
+        name = self._testMethodName
+        prob = LpProblem(name, const.LpMaximize)
+        x = LpVariable('x')
+        prob += (0 * x)
+        prob += (x >= 1)
+        prob.solve()
+        assert prob.valid() is True
+
+    def test_unbounded_problem__is_not_valid(self):
+        """Given an unbounded problem, where x will tend to infinity
+        to maximise the objective, assert that it is categorised
+        as invalid."""
+        name = self._testMethodName
+        prob = LpProblem(name, const.LpMaximize)
+        x = LpVariable('x')
+        prob += (1000 * x)
+        prob += (x >= 1)
+        prob.solve()
+        assert prob.valid() is False
+
+    def test_infeasible_problem__is_not_valid(self):
+        """Given a problem where x cannot converge to any value
+        given conflicting constraints, assert that it is invalid."""
+        name = self._testMethodName
+        prob = LpProblem(name, const.LpMaximize)
+        x = LpVariable('x')
+        prob += (1 * x)
+        prob += (x >= 2)  # Constraint x to be more than 2
+        prob += (x <= 1)  # Constraint x to be less than 1
+        prob.solve()
+        assert prob.valid() is False
+
 
 def pulpTestCheck(prob, solver, okstatus, sol=None,
                   reducedcosts=None,

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -940,7 +940,6 @@ class PuLPTest(unittest.TestCase):
         x = LpVariable('x')
         prob += (0 * x)
         prob += (x >= 1)
-        prob.solve()
         pulpTestCheck(prob, self.solver, [const.LpStatusOptimal])
         self.assertTrue(prob.valid())
 
@@ -953,7 +952,6 @@ class PuLPTest(unittest.TestCase):
         x = LpVariable('x')
         prob += (1000 * x)
         prob += (x >= 1)
-        prob.solve()
         self.assertFalse(prob.valid())
 
     def test_infeasible_problem__is_not_valid(self):
@@ -965,7 +963,6 @@ class PuLPTest(unittest.TestCase):
         prob += (1 * x)
         prob += (x >= 2)  # Constraint x to be more than 2
         prob += (x <= 1)  # Constraint x to be less than 1
-        prob.solve()
         pulpTestCheck(prob, self.solver, [const.LpStatusInfeasible, const.LpStatusUndefined])
         self.assertFalse(prob.valid())
 

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -943,7 +943,8 @@ class PuLPTest(unittest.TestCase):
         prob += (0 * x)
         prob += (x >= 1)
         prob.solve()
-        assert prob.valid() is True
+        pulpTestCheck(prob, self.solver, [const.LpStatusOptimal])
+        self.assertTrue(prob.valid())
 
     def test_unbounded_problem__is_not_valid(self):
         """Given an unbounded problem, where x will tend to infinity
@@ -955,7 +956,7 @@ class PuLPTest(unittest.TestCase):
         prob += (1000 * x)
         prob += (x >= 1)
         prob.solve()
-        assert prob.valid() is False
+        self.assertFalse(prob.valid())
 
     def test_infeasible_problem__is_not_valid(self):
         """Given a problem where x cannot converge to any value
@@ -967,7 +968,8 @@ class PuLPTest(unittest.TestCase):
         prob += (x >= 2)  # Constraint x to be more than 2
         prob += (x <= 1)  # Constraint x to be less than 1
         prob.solve()
-        assert prob.valid() is False
+        pulpTestCheck(prob, self.solver, [const.LpStatusInfeasible, const.LpStatusUndefined])
+        self.assertFalse(prob.valid())
 
 
 def pulpTestCheck(prob, solver, okstatus, sol=None,

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -932,10 +932,8 @@ class PuLPTest(unittest.TestCase):
         self.assertDictEqual(_dict1, _dict2)
 
     def test_unset_objective_value__is_valid(self):
-        """Given a valid problem that does not have
-        and driver in the objective function to direct it's minimisation
-        because the variable is multiplied by zero, assert that it
-        is still categorised as valid.
+        """Given a valid problem that does not converge,
+        assert that it is still categorised as valid.
         """
         name = self._testMethodName
         prob = LpProblem(name, const.LpMaximize)


### PR DESCRIPTION
As described in https://github.com/coin-or/pulp/issues/104, given a valid problem with variables which are not being driven by the objective to converge to a value, the dummy variables never get set at a value. This then causes the problem to be categorised as invalid correctly.

This PR changes the `valid` method on variables to allow those with the name `"__dummy"` to have a None value and still be valid.

There are three tests to confirm that 1. the previously invalid function is now valid, 2. an unbounded problem remains invalid, 3. an invalid problem remains invalid.