### PR TITLE
Initializing system_time correctly

### DIFF
--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -98,7 +98,7 @@ class SCIP_CMD(LpSolver_CMD):
             proc.append('-q')
         proc.extend(['-c', 'optimize', '-c', 'write solution "%s"' % tmpSol, '-c', 'quit'])
 
-        self.solution_time = clock()
+        self.solution_time = -clock()
         subprocess.check_call(proc, stdout=sys.stdout, stderr=sys.stderr)
         self.solution_time += clock()
 


### PR DESCRIPTION
Issue: `solution_time` in the SCIP API is not measuring the time needed for the subprocess correctly.

The change aligns the code with the versions in the Gurobi and CBC apis. E.g., compare https://github.com/coin-or/pulp/blob/c9221bd32837395f97ff85370155d7abc4e56c00/pulp/apis/coin_api.py#L439-L441

https://github.com/coin-or/pulp/blob/c9221bd32837395f97ff85370155d7abc4e56c00/pulp/apis/coin_api.py#L585-L587