### PR TITLE
Issue 83.1 pulp doesnt ignore double constraints

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -137,7 +137,6 @@ except ImportError:
 
 import re
 
-
 class LpElement(object):
     """Base class for LpVariable and LpConstraintVar
     """
@@ -145,7 +144,6 @@ class LpElement(object):
     illegal_chars = "-+[] ->/"
     expression = re.compile("[{}]".format(re.escape(illegal_chars)))
     trans = maketrans(illegal_chars, "________")
-
     def setName(self, name):
         if name:
             if self.expression.match(name):
@@ -153,10 +151,8 @@ class LpElement(object):
             self.__name = str(name).translate(self.trans)
         else:
             self.__name = None
-
     def getName(self):
         return self.__name
-
     name = property(fget=getName, fset=setName)
 
     def __init__(self, name):
@@ -173,7 +169,6 @@ class LpElement(object):
 
     def __str__(self):
         return self.name
-
     def __repr__(self):
         return self.name
 
@@ -300,7 +295,7 @@ class LpVariable(LpElement):
         return var
     from_dict = fromDict
 
-    def add_expression(self, e):
+    def add_expression(self,e):
         self.expression = e
         self.addVariableToConstraints(e)
 
@@ -702,10 +697,8 @@ class LpAffineExpression(_DICT_TYPE):
         return result
 
     def __repr__(self):
-        l = [
-            str(self[v]) + "*" + str(v)
-            for v in self.sorted_keys()
-        ]
+        l = [str(self[v]) + "*" + str(v)
+             for v in self.sorted_keys()]
         l.append(str(self.constant))
         s = " + ".join(l)
         return s
@@ -924,10 +917,8 @@ class LpAffineExpression(_DICT_TYPE):
         return [dict(name=k.name, value=v) for k, v in self.items()]
     to_dict = toDict
 
-
 class LpConstraint(LpAffineExpression):
     """An LP constraint"""
-
     def __init__(self, e = None, sense = const.LpConstraintEQ,
                   name = None, rhs = None):
         """

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -153,7 +153,7 @@ class LpElement(object):
             self.__name = None
     def getName(self):
         return self.__name
-    name = property(fget = getName, fset = setName)
+    name = property(fget = getName,fset = setName)
 
     def __init__(self, name):
         self.name = name

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -940,11 +940,16 @@ class LpConstraint(LpAffineExpression):
 
     @property
     def sub_constraints_to_add(self):
+        """Get the sub constraints which have not yet been added to the
+        model. Set the list of new constraints which have not yet been
+        added as empty. The full list of constraints remains tracked
+        within _sub_constraints."""
         new_sub_constraints = self._new_sub_constraints
         self._new_sub_constraints = []
         return new_sub_constraints
 
     def add(self, sub_constraint):
+        """Add a sub constraint."""
         self._sub_constraints.append(sub_constraint)
         self._new_sub_constraints.append(sub_constraint)
 

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -153,7 +153,7 @@ class LpElement(object):
             self.__name = None
     def getName(self):
         return self.__name
-    name = property(fget=getName, fset=setName)
+    name = property(fget = getName, fset = setName)
 
     def __init__(self, name):
         self.name = name

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -586,7 +586,6 @@ class LpAffineExpression(_DICT_TYPE):
     """
     #to remove illegal characters from the names
     trans = maketrans("-+[] ","_____")
-
     def setName(self,name):
         if name:
             self.__name = str(name).translate(self.trans)
@@ -1505,7 +1504,7 @@ class LpProblem(object):
     def add(self, constraint, name = None):
         self.addConstraint(constraint, name)
 
-    def addConstraint(self, constraint, name=None):
+    def addConstraint(self, constraint, name = None):
         if not isinstance(constraint, LpConstraint):
             raise TypeError("Can only add LpConstraint objects")
         if name:

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -993,7 +993,8 @@ class PuLPTest(unittest.TestCase):
         name = self._testMethodName
         prob = LpProblem(name, const.LpMinimize)
         x = LpVariable('x')
-        prob += 1 == x <= 5
+        prob += (1 == x <= 5)
+        prob += x <= 1
         prob += x
         prob.solve()
         assert x.value() == 1
@@ -1088,11 +1089,12 @@ def getSortedDict(prob, keyCons='name', keyVars='name'):
     _dict['variables'].sort(key=lambda v: v[keyVars])
     return _dict
 
+
 if __name__ == '__main__':
     # Tests
     runner = unittest.TextTestRunner(verbosity=0)
     runner.run(suite())
-    # # To run a single test:
+    # To run a single test:
     # suite = unittest.TestSuite()
-    # suite.addTest(PuLPTest('test_infeasible_problem__is_not_valid', PULP_CBC_CMD(msg=0)))
+    # suite.addTest(PuLPTest('test_pulp_060', PULP_CBC_CMD(msg=0)))
     # unittest.TextTestRunner(verbosity=0).run(suite)

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -971,6 +971,15 @@ class PuLPTest(unittest.TestCase):
         pulpTestCheck(prob, self.solver, [const.LpStatusInfeasible, const.LpStatusUndefined])
         self.assertFalse(prob.valid())
 
+    def test_double_constraint_respected(self):
+        name = self._testMethodName
+        prob = LpProblem(name, const.LpMinimize)
+        x = LpVariable('x')
+        prob += 1 <= x <= 5
+        prob += x
+        prob.solve()
+        assert x.value() == 1
+
 
 def pulpTestCheck(prob, solver, okstatus, sol=None,
                   reducedcosts=None,
@@ -1063,9 +1072,9 @@ def getSortedDict(prob, keyCons='name', keyVars='name'):
 
 if __name__ == '__main__':
     # Tests
-    runner = unittest.TextTestRunner(verbosity=0)
-    runner.run(suite())
+    # runner = unittest.TextTestRunner(verbosity=0)
+    # runner.run(suite())
     # To run a single test:
-    # suite = unittest.TestSuite()
-    # suite.addTest(PuLPTest('test_pulp_060', PULP_CBC_CMD(msg=0)))
-    # unittest.TextTestRunner(verbosity=0).run(suite)
+    suite = unittest.TestSuite()
+    suite.addTest(PuLPTest('test_double_constraint_respected', PULP_CBC_CMD(msg=0)))
+    unittest.TextTestRunner(verbosity=0).run(suite)

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -971,11 +971,29 @@ class PuLPTest(unittest.TestCase):
         pulpTestCheck(prob, self.solver, [const.LpStatusInfeasible, const.LpStatusUndefined])
         self.assertFalse(prob.valid())
 
-    def test_double_constraint_respected(self):
+    def test_double_constraint_respected__point_right(self):
         name = self._testMethodName
         prob = LpProblem(name, const.LpMinimize)
         x = LpVariable('x')
         prob += 1 <= x <= 5
+        prob += x
+        prob.solve()
+        assert x.value() == 1
+
+    def test_double_constraint_respected__point_left(self):
+        name = self._testMethodName
+        prob = LpProblem(name, const.LpMinimize)
+        x = LpVariable('x')
+        prob += 5 >= x >= 1
+        prob += x
+        prob.solve()
+        assert x.value() == 1
+
+    def test_double_constraint_respected__with_equals(self):
+        name = self._testMethodName
+        prob = LpProblem(name, const.LpMinimize)
+        x = LpVariable('x')
+        prob += 1 == x <= 5
         prob += x
         prob.solve()
         assert x.value() == 1
@@ -1072,9 +1090,9 @@ def getSortedDict(prob, keyCons='name', keyVars='name'):
 
 if __name__ == '__main__':
     # Tests
-    # runner = unittest.TextTestRunner(verbosity=0)
-    # runner.run(suite())
-    # To run a single test:
-    suite = unittest.TestSuite()
-    suite.addTest(PuLPTest('test_double_constraint_respected', PULP_CBC_CMD(msg=0)))
-    unittest.TextTestRunner(verbosity=0).run(suite)
+    runner = unittest.TextTestRunner(verbosity=0)
+    runner.run(suite())
+    # # To run a single test:
+    # suite = unittest.TestSuite()
+    # suite.addTest(PuLPTest('test_infeasible_problem__is_not_valid', PULP_CBC_CMD(msg=0)))
+    # unittest.TextTestRunner(verbosity=0).run(suite)


### PR DESCRIPTION
Addresses the issue described in https://github.com/coin-or/pulp/issues/83 where double comparison constraints have their first part ignored and only the second segment of the comparison respected.

As described in https://github.com/coin-or/pulp/issues/83#issuecomment-787116984, this is because currently there is only one version of self for any constraint lp expression, which is not built upon but instead defined over when a second comparison segment is made.

This pull request suggests adding tracking of sub_constraints, so the first part of the comparison is not lost, and both parts can be added to the greater problem.