### PR TITLE
Enabling SCIP inside Jupyter Notebooks

### DIFF
--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -99,8 +99,8 @@ class SCIP_CMD(LpSolver_CMD):
             proc.append('-q')
         proc.extend(['-c', 'optimize', '-c', 'write solution "%s"' % tmpSol, '-c', 'quit'])
 
-        stdout = self.none_if_fileno_unsupported(sys.stdout)
-        stderr = self.none_if_fileno_unsupported(sys.stderr)
+        stdout = self.firstWithFilenoSupport(sys.stdout, sys.__stdout__)
+        stderr = self.firstWithFilenoSupport(sys.stderr, sys.__stderr__)
 
         self.solution_time = -clock()
         subprocess.check_call(proc, stdout=stdout, stderr=stderr)
@@ -159,15 +159,17 @@ class SCIP_CMD(LpSolver_CMD):
                 except:
                     raise PulpSolverError("Can't read SCIP solver output: %r" % line)
 
-            return status, values\
+            return status, values
 
 
     @staticmethod
-    def none_if_fileno_unsupported(stream):
-        try:
-            stream.fileno()
-            return stream
-        except io.UnsupportedOperation:
-            return None
+    def firstWithFilenoSupport(*streams):
+        for stream in streams:
+            try:
+                stream.fileno()
+                return stream
+            except io.UnsupportedOperation:
+                pass
+        return None
 
 SCIP = SCIP_CMD

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -27,6 +27,7 @@
 from .core import LpSolver_CMD, subprocess, PulpSolverError, clock
 from .core import scip_path
 import os
+import io
 from .. import constants
 import sys
 
@@ -98,8 +99,11 @@ class SCIP_CMD(LpSolver_CMD):
             proc.append('-q')
         proc.extend(['-c', 'optimize', '-c', 'write solution "%s"' % tmpSol, '-c', 'quit'])
 
+        stdout = self.none_if_fileno_unsupported(sys.stdout)
+        stderr = self.none_if_fileno_unsupported(sys.stderr)
+
         self.solution_time = -clock()
-        subprocess.check_call(proc, stdout=sys.stdout, stderr=sys.stderr)
+        subprocess.check_call(proc, stdout=stdout, stderr=stderr)
         self.solution_time += clock()
 
         if not os.path.exists(tmpSol):
@@ -155,7 +159,15 @@ class SCIP_CMD(LpSolver_CMD):
                 except:
                     raise PulpSolverError("Can't read SCIP solver output: %r" % line)
 
-            return status, values
+            return status, values\
 
+
+    @staticmethod
+    def none_if_fileno_unsupported(stream):
+        try:
+            stream.fileno()
+            return stream
+        except io.UnsupportedOperation:
+            return None
 
 SCIP = SCIP_CMD


### PR DESCRIPTION
Bugfix for Issue #428.

**Problem:** `std.out` provided by Jupyter Notebooks is of type  `ipykernel.iostream.OutStream` which does not support the method `fileno`, required by inside method `subprocess.check_call`.

**Changes:** Using first of `sys.stdout` or `sys.__stdout__` which supports `fileno()`. If no options is supporting it,   None is used. Similar for `sys.stderr`.


![scip_working](https://user-images.githubusercontent.com/229571/113943527-2ea7ba00-9803-11eb-8fde-b6a824769512.png)

SCIP logs where shown for the Jupyter notebooks in the terminal used to start the notebook:


![Screenshot from 2021-04-08 13-33-52](https://user-images.githubusercontent.com/229571/114023162-d01a2480-9872-11eb-8558-ff4f070b0b0c.png)