### PR TITLE
Handling user provided gaps for SCIP

### DIFF
--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -30,7 +30,6 @@ import os
 import io
 from .. import constants
 import sys
-import resource
 import itertools
 
 
@@ -109,9 +108,9 @@ class SCIP_CMD(LpSolver_CMD):
         stdout = self.firstWithFilenoSupport(sys.stdout, sys.__stdout__)
         stderr = self.firstWithFilenoSupport(sys.stderr, sys.__stderr__)
 
-        self.solution_time = -resource.getrusage(resource.RUSAGE_CHILDREN).ru_utime
+        self.solution_time = -clock()
         subprocess.check_call(proc, stdout=stdout, stderr=stderr)
-        self.solution_time += resource.getrusage(resource.RUSAGE_CHILDREN).ru_utime
+        self.solution_time += clock()
 
         if not os.path.exists(tmpSol):
             raise PulpSolverError("PuLP: Error while executing "+self.path)

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -99,8 +99,8 @@ class SCIP_CMD(LpSolver_CMD):
             proc.append('-q')
         proc.extend(['-c', 'optimize', '-c', 'write solution "%s"' % tmpSol, '-c', 'quit'])
 
-        stdout = self.none_if_fileno_unsupported(sys.stdout)
-        stderr = self.none_if_fileno_unsupported(sys.stderr)
+        stdout = self.firstWithFilenoSupport(sys.stdout, sys.__stdout__)
+        stderr = self.firstWithFilenoSupport(sys.stderr, sys.__stderr__)
 
         self.solution_time = -clock()
         subprocess.check_call(proc, stdout=stdout, stderr=stderr)
@@ -159,15 +159,17 @@ class SCIP_CMD(LpSolver_CMD):
                 except:
                     raise PulpSolverError("Can't read SCIP solver output: %r" % line)
 
-            return status, values\
+            return status, values
 
 
     @staticmethod
-    def none_if_fileno_unsupported(stream):
-        try:
-            stream.fileno()
-            return stream
-        except io.UnsupportedOperation:
-            return None
+    def firstWithFilenoSupport(*streams):
+        for stream in streams:
+            try:
+                stream.fileno()
+                return stream
+            except io.UnsupportedOperation:
+                pass
+        return None
 
 SCIP = SCIP_CMD

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -27,6 +27,7 @@
 from .core import LpSolver_CMD, subprocess, PulpSolverError, clock
 from .core import scip_path
 import os
+import io
 from .. import constants
 import sys
 
@@ -98,8 +99,11 @@ class SCIP_CMD(LpSolver_CMD):
             proc.append('-q')
         proc.extend(['-c', 'optimize', '-c', 'write solution "%s"' % tmpSol, '-c', 'quit'])
 
+        stdout = self.none_if_fileno_unsupported(sys.stdout)
+        stderr = self.none_if_fileno_unsupported(sys.stderr)
+
         self.solution_time = -clock()
-        subprocess.check_call(proc, stdout=sys.stdout, stderr=sys.stderr)
+        subprocess.check_call(proc, stdout=stdout, stderr=stderr)
         self.solution_time += clock()
 
         if not os.path.exists(tmpSol):
@@ -155,7 +159,15 @@ class SCIP_CMD(LpSolver_CMD):
                 except:
                     raise PulpSolverError("Can't read SCIP solver output: %r" % line)
 
-            return status, values
+            return status, values\
 
+
+    @staticmethod
+    def none_if_fileno_unsupported(stream):
+        try:
+            stream.fileno()
+            return stream
+        except io.UnsupportedOperation:
+            return None
 
 SCIP = SCIP_CMD


### PR DESCRIPTION
Based on PR #427, this PR proposed to enable `absGap` and `relGap` for the scip api.

**Changes** (on top of #427)
- passing arguments given to solver
- option handling aligned with the one for `coin_api.py`
- status for "gap limit reached" changed to OPTIMAL (optimal wrt. given gap)
-  measuring time corrected (`clock()` does not measure the time for the subprocess call)

**Example**
Bin packing MIP with known optimum (number of bins). 
https://github.com/wookenny/pulp/blob/6f36880525356466e49f0f97af61412a39764384/SCIP_handling_gap_reached.ipynb

To be considered later: 
If a `timeLimit` is given
- `COIN_CMD` solved the given binpacking problem with 11 bins, 10 is optimal. Pulp reports this solution as `OPTIMAL`.
- `SCIP` fins 11 bins as well, the status is "time limit reached". Pulp reports status Not solved.

**At maintainer:** I can also remove the commits from #427 to obtain an independent PR.
