### PR TITLE
Handling user provided gaps in SCIP

### DIFF
--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -30,6 +30,7 @@ import os
 import io
 from .. import constants
 import sys
+import itertools
 
 
 class SCIP_CMD(LpSolver_CMD):
@@ -45,6 +46,8 @@ class SCIP_CMD(LpSolver_CMD):
         msg=True,
         options=None,
         timeLimit=None,
+        gapRel=None,
+        gapAbs=None,
         maxNodes=None,
     ):
         """
@@ -54,6 +57,8 @@ class SCIP_CMD(LpSolver_CMD):
         :param bool keepFiles: if True, files are saved in the current directory and not deleted after solving
         :param str path: path to the solver binary
         :param float timeLimit: maximum time for solver (in seconds)
+        :param float gapRel: relative gap tolerance for the solver to stop (in fraction)
+        :param float gapAbs: absolute gap tolerance for the solver to stop
         :param int maxNodes: max number of nodes during branching. Stops the solving when reached.
         """
         LpSolver_CMD.__init__(
@@ -64,6 +69,8 @@ class SCIP_CMD(LpSolver_CMD):
             path=path,
             keepFiles=keepFiles,
             timeLimit=timeLimit,
+            gapRel=gapRel,
+            gapAbs=gapAbs,
             maxNodes=maxNodes,
         )
 
@@ -75,7 +82,7 @@ class SCIP_CMD(LpSolver_CMD):
         "stall node limit reached": constants.LpStatusNotSolved,
         "time limit reached": constants.LpStatusNotSolved,
         "memory limit reached": constants.LpStatusNotSolved,
-        "gap limit reached": constants.LpStatusNotSolved,
+        "gap limit reached": constants.LpStatusOptimal,
         "solution limit reached": constants.LpStatusNotSolved,
         "solution improvement limit reached": constants.LpStatusNotSolved,
         "restart limit reached": constants.LpStatusNotSolved,
@@ -109,9 +116,10 @@ class SCIP_CMD(LpSolver_CMD):
         if self.timeLimit is not None:
             proc.extend(["-c", "set limits time {}".format(self.timeLimit)])
 
-        maxNodes = self.optionsDict.get("maxNodes")
-        if maxNodes is not None:
-            proc.extend(["-c", "set limits nodes {}".format(maxNodes)])
+        options = self.options + self.getOptions()
+        options = list(itertools.chain(*[("-c", o) for o in options]))
+        proc.extend(options)
+
         proc.extend(self.options)
         if not self.msg:
             proc.append("-q")
@@ -140,6 +148,20 @@ class SCIP_CMD(LpSolver_CMD):
         lp.assignStatus(status)
         self.delete_tmp_files(tmpLp, tmpSol)
         return status
+
+    def getOptions(self):
+        params_eq = dict(
+            timeLimit="set limits time {}",
+            gapRel="set limits gap {}",
+            gapAbs="set limits absgap {}",
+            maxNodes="set limits nodes {}",
+        )
+
+        return [
+            v.format(self.optionsDict[k])
+            for k, v in params_eq.items()
+            if self.optionsDict.get(k) is not None
+        ]
 
     @staticmethod
     def readsol(filename):
@@ -183,7 +205,6 @@ class SCIP_CMD(LpSolver_CMD):
 
             return status, values
 
-
     @staticmethod
     def firstWithFilenoSupport(*streams):
         for stream in streams:
@@ -193,5 +214,6 @@ class SCIP_CMD(LpSolver_CMD):
             except io.UnsupportedOperation:
                 pass
         return None
+
 
 SCIP = SCIP_CMD

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -151,7 +151,6 @@ class SCIP_CMD(LpSolver_CMD):
 
     def getOptions(self):
         params_eq = dict(
-            timeLimit="set limits time {}",
             gapRel="set limits gap {}",
             gapAbs="set limits absgap {}",
             maxNodes="set limits nodes {}",


### PR DESCRIPTION
Opened instead of #429,
this PR proposed to enable `absGap` and `relGap` for the scip api.

**Changes**
- passing arguments given to solver
- option handling aligned with the one for `coin_api.py`
- status for "gap limit reached" changed to OPTIMAL (optimal wrt. given gap)

**Example**
Bin packing MIP with known optimum (number of bins). 
https://github.com/wookenny/pulp/blob/6f36880525356466e49f0f97af61412a39764384/SCIP_handling_gap_reached.ipynb