### PR TITLE
Measuring solutionTime including child processes

### DIFF
--- a/pulp/apis/core.py
+++ b/pulp/apis/core.py
@@ -33,10 +33,14 @@ the current version
 import os
 import sys
 
-try:
-    from time import process_time as clock
-except ImportError:
-    from time import clock
+
+if os.name == "posix":
+    from ..utilities import resource_clock as clock
+else:
+    try:
+        from time import monotonic as clock
+    except ImportError:
+        from time import clock
 
 try:
     import configparser
@@ -49,7 +53,6 @@ except AttributeError:
 from .. import sparse
 from .. import constants as const
 
-import warnings
 import logging
 
 try:
@@ -91,7 +94,7 @@ class PulpSolverError(const.PulpError):
 
 # import configuration information
 def initialize(filename, operating_system="linux", arch="64"):
-    """ reads the configuration file to initialise the module"""
+    """reads the configuration file to initialise the module"""
     here = os.path.dirname(filename)
     config = Parser({"here": here, "os": operating_system, "arch": arch})
     config.read(filename)
@@ -239,7 +242,7 @@ class LpSolver:
     def actualResolve(self, lp, **kwargs):
         """
         uses existing problem information and solves the problem
-        If it is not implelemented in the solver
+        If it is not implemented in the solver
         just solve again
         """
         self.actualSolve(lp, **kwargs)

--- a/pulp/tests/bin_packing_problem.py
+++ b/pulp/tests/bin_packing_problem.py
@@ -1,0 +1,53 @@
+from pulp import *
+import random
+from itertools import product
+
+
+def _bin_packin_instance(bins, seed=0):
+    packed_bins = [[] for _ in range(bins)]
+    bin_size = bins * 100
+    random.seed(seed)
+    for i in range(len(packed_bins)):
+        remaining_size = bin_size
+        while remaining_size >= 1:
+            item = random.randrange(1, remaining_size + 10)
+            packed_bins[i].append(item)
+            remaining_size -= item
+        packed_bins[i][-1] += remaining_size
+    all_items_with_bin = [(n, i) for i, l in enumerate(packed_bins) for n in l]
+
+    random.shuffle(all_items_with_bin)
+    items, packing = zip(*all_items_with_bin)
+    return items, packing, bin_size
+
+
+def create_bin_packing_problem(bins, seed=0):
+    items, packing, bin_size = _bin_packin_instance(bins=bins, seed=seed)
+
+    prob = LpProblem("bin_packing", LpMinimize)
+
+    bin_indices = [i for i in range(len(items))]
+    item_indices = [i for i in range(len(items))]
+
+    using_bin = LpVariable.dicts("y", bin_indices, cat=LpBinary)
+    items_packed = LpVariable.dicts(
+        "x", indexs=product(item_indices, bin_indices), cat=LpBinary
+    )
+
+    prob += lpSum(using_bin), "objective"
+
+    # pack every item
+    for i in item_indices:
+        prob += lpSum(
+            items_packed[i, b] for b in bin_indices
+        ) == 1, "pack_item_{}".format(i)
+
+    # no bin overfilled
+    for b in bin_indices:
+        expr = (
+            lpSum([items[i] * items_packed[i, b] for i in item_indices])
+            <= bin_size * using_bin[b]
+        )
+        prob += expr, "respect_bin_size_{}".format(b)
+
+    return prob

--- a/pulp/utilities.py
+++ b/pulp/utilities.py
@@ -3,6 +3,12 @@ import itertools
 import collections
 
 
+def resource_clock():
+    import resource
+
+    return resource.getrusage(resource.RUSAGE_CHILDREN).ru_utime
+
+
 def isNumber(x):
     """Returns true if x is an int or a float"""
     return isinstance(x, (int, float))


### PR DESCRIPTION
**Trigger:**
Variable `solutionTime` of `LpProblem` is not measuring the CPU time required by the solver correctly.

See the differences in `walltime` and `solutionTime` for the linked python [file](https://gist.github.com/wookenny/b9600a26a98b4fbbdd8329c00f55e7e7#file-report_optimization_time-py):

```
PULP_CBC_CMD
	objective:   8.00 (Optimal)
	time:   0.02s 	walltime:   6.43s
COIN_CMD
	objective:   8.00 (Optimal)
	time:   0.02s 	walltime:   6.72s
PULP_CHOCO_CMD
	objective:   4.00 (Optimal)
	time:   0.00s 	walltime:   0.41s
SCIP_CMD
	objective:  14.00 (Optimal)
	time:   0.11s 	walltime:   7.72s
```

**Changes:**
Using `resources` to get CPU time of child processes.

Resulting output:
```
PULP_CBC_CMD
	objective:   8.00 (Optimal)
	time:   6.22s 	walltime:   6.42s
COIN_CMD
	objective:   8.00 (Optimal)
	time:   6.42s 	walltime:   6.62s
PULP_CHOCO_CMD
	objective:   4.00 (Optimal)
	time:   0.83s 	walltime:   0.41s
SCIP_CMD
	objective:  14.00 (Optimal)
	time:   6.97s 	walltime:   7.26s
```

**Warning:** Only tested with the mentioned solver due to licenses. Please use the provided file and add available solver with appropriate number of bins.