### PR TITLE
MOSEK api now uses one Env object across all instances (Class variable).

### DIFF
--- a/pulp/apis/mosek_api.py
+++ b/pulp/apis/mosek_api.py
@@ -36,8 +36,8 @@ class MOSEK(LpSolver):
     try:
         global mosek
         import mosek
+        env = mosek.Env()
     except ImportError:
-
         def available(self):
             """True if Mosek is available."""
             return False
@@ -45,7 +45,6 @@ class MOSEK(LpSolver):
         def actualSolve(self, lp, callback=None):
             """Solves a well-formulated lp problem."""
             raise PulpSolverError("MOSEK : Not Available")
-
     else:
 
         def __init__(
@@ -110,9 +109,7 @@ class MOSEK(LpSolver):
             self.var_dict = {}
             # Checking for repeated names
             lp.checkDuplicateVars()
-            # Creating a MOSEK environment
-            self.env = mosek.Env()
-            self.task = self.env.Task()
+            self.task = MOSEK.env.Task()
             self.task.appendcons(self.numcons)
             self.task.appendvars(self.numvars)
             if self.msg:

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -27,7 +27,7 @@
 
 """
 PuLP is an LP modeler written in python. PuLP can generate MPS or LP files
-and call GLPK[1], COIN CLP/CBC[2], CPLEX[3], and GUROBI[4] to solve linear
+and call GLPK[1], COIN CLP/CBC[2], CPLEX[3], GUROBI[4] and MOSEK[5] to solve linear
 problems.
 
 See the examples directory for examples.
@@ -89,6 +89,7 @@ References:
 [2] http://www.coin-or.org/
 [3] http://www.cplex.com/
 [4] http://www.gurobi.com/
+[5] http://www.mosek.com/
 """
 
 import sys


### PR DESCRIPTION
Reason for PR: MOSEK support was contacted by a user who reported some issues with floating license check-in/check-out. 

Cause: The MOSEK API was creating one MOSEK Env object per instance. This could cause troubles when people use our floating licenses as each environment will ask for its own license. 

Fix: Each instance of the MOSEK(LpSolver) class is now going to share the same environment. 

P.S.: I have also added MOSEK's name at one place in your documentation (as you can see in the files changed).
