### PR TITLE
Add black to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 - sudo apt-get install -qq glpk-utils
 - if [[ $TRAVIS_PYTHON_VERSION ne pypy3 ]]; then
 - echo "Using black to check Python code"
-- if [[ $TRAVIS_PYTHON_VERSION ne pypy3 ]]; then pip install black; black --check *.py; fi
+- if [[ $TRAVIS_PYTHON_VERSION != pypy3 ]] ; then pip install black ; black --check *.py ; fi
 
 install:
 - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq glpk-utils
 - echo "Using black to check Python code"
+- pip install black
 - black --check *.py
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 - sudo apt-get install -qq glpk-utils
 - if [[ $TRAVIS_PYTHON_VERSION ne pypy3 ]]; then
 - echo "Using black to check Python code"
-- if [[ $TRAVIS_PYTHON_VERSION != pypy3 ]] ; then pip install black ; black --check *.py ; fi
+- if [[ $TRAVIS_PYTHON_VERSION != "pypy3" ]] ; then pip install black ; black --check *.py ; fi
 
 install:
 - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq glpk-utils
+- echo "Using black to check Python code"
+- black --check *.py
 
 install:
 - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,8 @@ matrix:
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq glpk-utils
-- if [[ $TRAVIS_PYTHON_VERSION ne pypy3 ]]; then
 - echo Using black to check Python code
-- echo $TRAVIS_PYTHON_VERSION
+- echo Using python version $TRAVIS_PYTHON_VERSION
 - if [[ $TRAVIS_PYTHON_VERSION != "pypy3" ]] ; then pip install black ; black --check *.py ; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq glpk-utils
 - echo Using black to check Python code
-- echo Using python version $TRAVIS_PYTHON_VERSION
 - if [[ $TRAVIS_PYTHON_VERSION != "pypy3" ]] ; then pip install black ; black --check *.py ; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq glpk-utils
 - if [[ $TRAVIS_PYTHON_VERSION ne pypy3 ]]; then
-- echo "Using black to check Python code"
+- echo Using black to check Python code
+- echo $TRAVIS_PYTHON_VERSION
 - if [[ $TRAVIS_PYTHON_VERSION != "pypy3" ]] ; then pip install black ; black --check *.py ; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ matrix:
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq glpk-utils
+- if [[ $TRAVIS_PYTHON_VERSION ne pypy3 ]]; then
 - echo "Using black to check Python code"
-- pip install black
-- black --check *.py
+- if [[ $TRAVIS_PYTHON_VERSION ne pypy3 ]]; then pip install black; black --check *.py; fi
 
 install:
 - pip install .

--- a/pulp/apis/core.py
+++ b/pulp/apis/core.py
@@ -91,7 +91,7 @@ class PulpSolverError(const.PulpError):
 
 # import configuration information
 def initialize(filename, operating_system="linux", arch="64"):
-    """ reads the configuration file to initialise the module"""
+    """reads the configuration file to initialise the module"""
     here = os.path.dirname(filename)
     config = Parser({"here": here, "os": operating_system, "arch": arch})
     config.read(filename)

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -148,7 +148,7 @@ class CPLEX_CMD(LpSolver_CMD):
                 solStatus,
             ) = self.readsol(tmpSol)
         self.delete_tmp_files(tmpLp, tmpMst, tmpSol)
-        if self.optionsDict.get('logPath') != "cplex.log":
+        if self.optionsDict.get("logPath") != "cplex.log":
             self.delete_tmp_files("cplex.log")
         if status != constants.LpStatusInfeasible:
             lp.assignVarsVals(values)

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -2079,7 +2079,7 @@ class FixedElasticSubProblem(LpProblem):
         return self.constraint.value() - self.constant - upVar - lowVar - freeVar
 
     def deElasticize(self):
-        """ de-elasticize constraint """
+        """de-elasticize constraint"""
         self.upVar.upBound = 0
         self.lowVar.lowBound = 0
 

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -1103,9 +1103,15 @@ class PuLPTest(unittest.TestCase):
         prob += 1 * x
         prob += x >= 2  # Constraint x to be more than 2
         prob += x <= 1  # Constraint x to be less than 1
-        if self.solver.name in ['GUROBI_CMD']:
+        if self.solver.name in ["GUROBI_CMD"]:
             pulpTestCheck(
-                prob, self.solver, [const.LpStatusNotSolved, const.LpStatusInfeasible, const.LpStatusUndefined]
+                prob,
+                self.solver,
+                [
+                    const.LpStatusNotSolved,
+                    const.LpStatusInfeasible,
+                    const.LpStatusUndefined,
+                ],
             )
         else:
             pulpTestCheck(

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ with open(readme_name, "r") as fh:
 setup(
     name="PuLP",
     version=VERSION,
-    description="PuLP is an LP modeler written in python. PuLP can generate MPS or LP files and call GLPK, COIN CLP/CBC, CPLEX, and GUROBI to solve linear problems.",
+    description="PuLP is an LP modeler written in python. PuLP can generate MPS"
+    " or LP files and call GLPK, COIN CLP/CBC, CPLEX, and GUROBI to"
+    " solve linear problems.",
     long_description=long_description,
     long_description_content_type="text/x-rst",
     keywords=["Optimization", "Linear Programming", "Operations Research"],


### PR DESCRIPTION
I previously ran black over the codebase here https://github.com/coin-or/pulp/pull/430, as a pr which came from issue https://github.com/coin-or/pulp/issues/423.

To up-keep this in a more automated manner I have also now added running it to travis, since your travis only has python 3.6+ versions (black cannot be installed with 3.5 or earlier).

This would take out the need for anyone to check that it is kept up to date manually, since the changes to keep it in line with the standard would always be displayed as part of the travis check.

I also made any changes to make it valid with travis since recent prs.

Many thanks!