### PR TITLE
Add black to GitHub actions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,9 +30,9 @@ jobs:
     - name: Test with pulptest
       run: pulptest
     - name: Code Quality
-      if: ${{ matrix.python-version }} != 2.7
+      if: ${{ matrix.python-version >= 3.6 }}
       run: |
         echo Python version ${{ matrix.python-version }}
-        echo Version is not 2.7 ${{ matrix.python-version }} != 2.7
+        echo Version is not 2.7 ${{ matrix.python-version >= 3.6 }}
         pip install black
         black . --check

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,5 @@ jobs:
     - name: Code Quality
       if: ${{ matrix.python-version >= 3.6 }}
       run: |
-        echo Python version ${{ matrix.python-version }}
-        echo Version is not 2.7 ${{ matrix.python-version >= 3.6 }}
         pip install black
         black . --check

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Test with pulptest
       run: pulptest
     - name: Code Quality
-      if: ${{ matrix.python-version }} >= 3.6
+      if: ${{ matrix.python-version }} != 2.7
       run: |
         echo Python version ${{ matrix.python-version }}
         echo Version is greater than 3.6 ${{ matrix.python-version }} >= 3.6

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,5 +32,7 @@ jobs:
     - name: Code Quality
       if: ${{ matrix.python-version }} >= 3.6
       run: |
+        echo Python version ${{ matrix.python-version }}
+        echo Version is greater than 3.6 ${{ matrix.python-version }} >= 3.6
         pip install black
         black . --check

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,8 +30,7 @@ jobs:
     - name: Test with pulptest
       run: pulptest
     - name: Code Quality
-      exclude:
-        - python-version: [2.7, 3.5]
+      if: ${{ matrix.python-version }} >= 3.6
       run: |
         pip install black
         black . --check

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -33,4 +33,4 @@ jobs:
       if: ${{ matrix.python-version >= 3.6 }}
       run: |
         pip install black
-        black . --check
+        black pulp/ --check

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -33,6 +33,6 @@ jobs:
       if: ${{ matrix.python-version }} != 2.7
       run: |
         echo Python version ${{ matrix.python-version }}
-        echo Version is greater than 3.6 ${{ matrix.python-version }} >= 3.6
+        echo Version is not 2.7 ${{ matrix.python-version }} != 2.7
         pip install black
         black . --check

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,3 +29,9 @@ jobs:
         pip install .
     - name: Test with pulptest
       run: pulptest
+    - name: Code Quality
+      exclude:
+        - python-version: [2.7, 3.5]
+      run: |
+        pip install black
+        black . --check

--- a/pulp/apis/core.py
+++ b/pulp/apis/core.py
@@ -91,7 +91,7 @@ class PulpSolverError(const.PulpError):
 
 # import configuration information
 def initialize(filename, operating_system="linux", arch="64"):
-    """ reads the configuration file to initialise the module"""
+    """reads the configuration file to initialise the module"""
     here = os.path.dirname(filename)
     config = Parser({"here": here, "os": operating_system, "arch": arch})
     config.read(filename)

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -148,7 +148,7 @@ class CPLEX_CMD(LpSolver_CMD):
                 solStatus,
             ) = self.readsol(tmpSol)
         self.delete_tmp_files(tmpLp, tmpMst, tmpSol)
-        if self.optionsDict.get('logPath') != "cplex.log":
+        if self.optionsDict.get("logPath") != "cplex.log":
             self.delete_tmp_files("cplex.log")
         if status != constants.LpStatusInfeasible:
             lp.assignVarsVals(values)

--- a/pulp/apis/mosek_api.py
+++ b/pulp/apis/mosek_api.py
@@ -36,8 +36,10 @@ class MOSEK(LpSolver):
     try:
         global mosek
         import mosek
+
         env = mosek.Env()
     except ImportError:
+
         def available(self):
             """True if Mosek is available."""
             return False
@@ -45,6 +47,7 @@ class MOSEK(LpSolver):
         def actualSolve(self, lp, callback=None):
             """Solves a well-formulated lp problem."""
             raise PulpSolverError("MOSEK : Not Available")
+
     else:
 
         def __init__(

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -2079,7 +2079,7 @@ class FixedElasticSubProblem(LpProblem):
         return self.constraint.value() - self.constant - upVar - lowVar - freeVar
 
     def deElasticize(self):
-        """ de-elasticize constraint """
+        """de-elasticize constraint"""
         self.upVar.upBound = 0
         self.lowVar.lowBound = 0
 

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -1103,9 +1103,15 @@ class PuLPTest(unittest.TestCase):
         prob += 1 * x
         prob += x >= 2  # Constraint x to be more than 2
         prob += x <= 1  # Constraint x to be less than 1
-        if self.solver.name in ['GUROBI_CMD']:
+        if self.solver.name in ["GUROBI_CMD"]:
             pulpTestCheck(
-                prob, self.solver, [const.LpStatusNotSolved, const.LpStatusInfeasible, const.LpStatusUndefined]
+                prob,
+                self.solver,
+                [
+                    const.LpStatusNotSolved,
+                    const.LpStatusInfeasible,
+                    const.LpStatusUndefined,
+                ],
             )
         else:
             pulpTestCheck(


### PR DESCRIPTION
I previously ran black over the codebase here https://github.com/coin-or/pulp/pull/430, as a pr which came from issue https://github.com/coin-or/pulp/issues/423.

To up-keep this in a more automated manner I have also now added running it to github actions.

This would take out the need for anyone to check that it is kept up to date manually, since the changes to keep it in line with the standard would always be displayed as part of the travis check.

I also made any changes to make it valid with black since recent prs.

Many thanks!