### PR TITLE
Measuring solution time as walltime

### DIFF
--- a/pulp/apis/coin_api.py
+++ b/pulp/apis/coin_api.py
@@ -164,6 +164,8 @@ class COIN_CMD(LpSolver_CMD):
             self.writesol(tmpMst, lp, vs, variablesNames, constraintsNames)
             cmds += "mips {} ".format(tmpMst)
         if self.timeLimit is not None:
+            if self.optionsDict.get('threads', 1) > 1:
+                warnings.warn("Beware: CBC uses timeLimit as cpu_time, not wall_time")
             cmds += "sec %s " % self.timeLimit
         options = self.options + self.getOptions()
         for option in options:

--- a/pulp/apis/coin_api.py
+++ b/pulp/apis/coin_api.py
@@ -164,7 +164,8 @@ class COIN_CMD(LpSolver_CMD):
             self.writesol(tmpMst, lp, vs, variablesNames, constraintsNames)
             cmds += "mips {} ".format(tmpMst)
         if self.timeLimit is not None:
-            if self.optionsDict.get('threads', 1) > 1:
+            num_threads = self.optionsDict.get("threads", 1)
+            if num_threads is not None and int(num_threads) > 1:
                 warnings.warn("Beware: CBC uses timeLimit as cpu_time, not wall_time")
             cmds += "sec %s " % self.timeLimit
         options = self.options + self.getOptions()

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -94,6 +94,7 @@ References:
 
 import sys
 import warnings
+from time import time
 
 from .apis import LpSolverDefault, PULP_CBC_CMD
 from .apis.core import clock
@@ -1873,9 +1874,11 @@ class LpProblem(object):
             solver = LpSolverDefault
         wasNone, dummyVar = self.fixObjective()
         # time it
-        self.solutionTime = -clock()
+        self.solutionCpuTime = -clock()
+        self.solutionTime = -time()
         status = solver.actualSolve(self, **kwargs)
-        self.solutionTime += clock()
+        self.solutionTime += time()
+        self.solutionCpuTime += clock()
         self.restoreObjective(wasNone, dummyVar)
         self.solver = solver
         return status

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -1132,13 +1132,16 @@ class PuLPTest(unittest.TestCase):
             self.solver.timeLimit = time_limit
             prob.solve(self.solver)
 
+            if self.solver.name in (PULP_CBC_CMD, COIN_CMD):
+                reported_time = prob.solutionCpuTime
+            else:
+                reported_time = prob.solutionTime
             self.assertAlmostEqual(
-                prob.solutionTime,
+                reported_time,
                 time_limit,
                 delta=2,
                 msg="optimization time for solver {}".format(self.solver.name),
             )
-        self.assertTrue(True)
 
     def test_false_constraint(self):
         prob = LpProblem(self._testMethodName, const.LpMinimize)


### PR DESCRIPTION
## Changes
- Reporting `solutionTime` as wall time. 
- Additionally, measuring `solutionCpuTime` as done before.
- Warning when 

TODO: 
- [ ] Adjust tests and verify with additional solver.

### Example behavior:

This branch: https://gist.github.com/wookenny/d326022fedefd9266c101a2ef6365c9f
Master: https://gist.github.com/wookenny/924a2f61496547a975bd8f9a80dbdb7a