### PR TITLE
Add LpProblem.variables to docs

### DIFF
--- a/doc/source/technical/pulp.rst
+++ b/doc/source/technical/pulp.rst
@@ -47,6 +47,7 @@ The LpProblem Class
    .. automethod:: writeMPS
    .. automethod:: toJson
    .. automethod:: fromJson
+   .. automethod:: variables
 
 Variables and Expressions
 -------------------------

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -1615,13 +1615,10 @@ class LpProblem(object):
 
     def variables(self):
         """
-        Returns a list of the problem variables
+        Returns the problem variables
 
-        Inputs:
-            - none
-
-        Returns:
-            - A list of the problem variables
+        :return: A list containing the problem variables
+        :rtype: (list, :py:class:`LpVariable`)
         """
         if self.objective:
             self.addVariables(list(self.objective.keys()))


### PR DESCRIPTION
Hello,

this adds `LpProblem.variables` to the documentation as it is a quite useful method and is largely used in the examples.

