### PR TITLE
Fix documentation code line references after code reformatting

### DIFF
--- a/doc/source/CaseStudies/a_blending_problem.rst
+++ b/doc/source/CaseStudies/a_blending_problem.rst
@@ -300,13 +300,13 @@ programming. The ingredients are the reference keys, with the numbers as
 the data.
 
 .. literalinclude:: ../../../examples/WhiskasModel2.py
-    :lines: 10-51
+    :lines: 10-61
 
 The ``prob`` variable is created to contain the formulation, and the
 usual parameters are passed into :obj:`~pulp.LpProblem`.
 
 .. literalinclude:: ../../../examples/WhiskasModel2.py
-    :lines: 53-54
+    :lines: 63-64
 
 A dictionary called ``ingredient_vars`` is created which contains
 the LP variables, with their defined lower bound of zero. The reference
@@ -314,7 +314,7 @@ keys to the dictionary are the Ingredient names, and the data is
 ``Ingr_IngredientName``. (e.g. MUTTON: Ingr_MUTTON)
 
 .. literalinclude:: ../../../examples/WhiskasModel2.py
-    :lines: 56-57
+    :lines: 66-67
    
 Since ``costs`` and ``ingredient_vars`` are now dictionaries with the
 reference keys as the Ingredient names, the data can be simply extracted
@@ -323,12 +323,12 @@ elements of the resulting list. Thus the objective function is simply
 entered and assigned a name:
 
 .. literalinclude:: ../../../examples/WhiskasModel2.py
-    :lines: 59-60
+    :lines: 69-73
     
 Further list comprehensions are used to define the other 5 constraints, which are also each given names describing them.
 
 .. literalinclude:: ../../../examples/WhiskasModel2.py
-    :lines: 62-67
+    :lines: 75-92
  
 Following this, the :ref:`writeLP<writeLP>` line etc follow exactly the same as
 in the simplified example.

--- a/doc/source/CaseStudies/a_set_partitioning_problem.rst
+++ b/doc/source/CaseStudies/a_set_partitioning_problem.rst
@@ -25,12 +25,12 @@ First we use :func:`~pulp.allcombinations` to generate a list of all
 possible table seatings.
 
 .. literalinclude:: ../../../examples/wedding.py
-    :lines: 20-22
+    :lines: 22-23
 
 Then we create a binary variable that will be 1 if the table will be in the solution, or zero otherwise.
 
 .. literalinclude:: ../../../examples/wedding.py
-    :lines: 24-28
+    :lines: 25-28
 
 We create the :class:`~pulp.LpProblem` and then make the objective function. Note that
 happiness function used in this script would be difficult to model in any other way.
@@ -41,13 +41,13 @@ happiness function used in this script would be difficult to model in any other 
 We specify the total number of tables allowed in the solution.
 
 .. literalinclude:: ../../../examples/wedding.py
-    :lines: 34-35
+    :lines: 34-38
 
 This set of constraints defines the set partitioning problem by guaranteeing that a guest is allocated to
 exactly one table.
 
 .. literalinclude:: ../../../examples/wedding.py
-    :lines: 38-41
+    :lines: 40-45
     
 The full file can be found here `wedding.py <https://projects.coin-or.org/PuLP/browser/trunk/examples/wedding.py?format=txt>`_
 

--- a/doc/source/CaseStudies/a_sudoku_problem.rst
+++ b/doc/source/CaseStudies/a_sudoku_problem.rst
@@ -76,12 +76,12 @@ Solution
 The introductory commenting and import statement are entered
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 1-10
+    :lines: 1-9
 
 In the unique case of the sudoku problem, the row names, column names and variable option values are all the exact same list of numbers from 1 to 9.
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 11-13
+    :lines: 11-12
 
 
 A list called `Boxes` is created with 9 elements, each being another list. These 9 lists correspond to each of the 9 boxes, and each of the lists contains tuples as the elements with the row and column indices for each square in that box. Explicitly entering the values in a similar way to the following would have had the same effect (but would have been a waste of time): 
@@ -94,49 +94,49 @@ Therefore, Boxes[0] will return a list of tuples containing the locations of eac
 The prob variable is created to contain the problem data.
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 20-22
+    :lines: 21-22
 
 
 The 729 problem variables are created since the `(Vals,Rows,Cols)` creates a variable for each combination of value, row and column. An example variable would be: Choice_4_2_9, and it is defined to be a binary variable (able to take only the integers 1 or 0. If Choice_4_2_9 was 1, it would mean the number 4 was present in the square situated in row 2, column 9. (If it was 0, it would mean there was not a 4 there)
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 23-25
+    :lines: 24-25
 
 As explained above, we don't define an objective function since we are only concerned with any variable combination that can satisfy the constraints.
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 26-27
+    :lines: 27-27
 
 Since there are 9 variables for each square, it is important to specify that only exactly one of them can take the value of 1 (and the rest are 0). Therefore, the below code reads: for each of the 81 squares, the sum of all the 9 variables (each representing a value that could be there) relating to that particular square must equal 1. 
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 28-32
+    :lines: 29-32
 
 These constraints ensure that each number (value) can only occur once in each row, column and box.
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 33-43
+    :lines: 34-43
 
 The starting numbers are entered as constraints i.e a 5 in row 1 column 1 is true.
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 44-79
+    :lines: 45-79
 
 The problem is written to an LP file, solved using PuLP's choice of solver and the solution status is printed to the screen 
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 80-88
+    :lines: 81-88
 
 
 Instead of printing out all 729 of the binary problem variables and their respective values, it is more meaningful to draw the solution in a text file. The code also puts lines inbetween every third row and column to make the solution easier to read. The sudokuout.txt file is created in the same folder as the .py file.
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 89-106
+    :lines: 90-106
 
 A note of the location of the solution is printed to the solution
 
 .. literalinclude:: ../../../examples/Sudoku1.py
-    :lines: 107-108
+    :lines: 108-109
 
 
 The full file above is given provided `Sudoku1.py <https://projects.coin-or.org/PuLP/browser/trunk/examples/Sudoku1.py?format=txt>`_
@@ -153,6 +153,6 @@ In the above formulation we did not consider the fact that there may be multiple
 We can make our code return all the solutions by editing our code as shown after the `prob.writeLP` line. Essentially we are just looping over the solve statement, and each time after a successful solve, adding a constraint that the same solution cannot be used again. When there are no more solutions, our program ends.
 
 .. literalinclude:: ../../../examples/Sudoku2.py
-    :lines: 88-114
+    :lines: 89-124
 
 The full file using this is available `Sudoku2.py <https://github.com/stumitchell/pulp-or/raw/master/examples/Sudoku2.py>`_. When using this code for sudoku problems with a large number of solutions, it could take a very long time to solve them all. To create sudoku problems with multiple solutions from unique solution sudoku problem, you can simply delete a starting number constraint. You may find that deleting several constraints will still lead to a single optimal solution but the removal of one particular constraint leads to a sudden dramatic increase in the number of solutions. 

--- a/doc/source/CaseStudies/a_transportation_problem.rst
+++ b/doc/source/CaseStudies/a_transportation_problem.rst
@@ -145,7 +145,7 @@ First, start your Python file with a heading and the import PuLP statement:
 The start of the formulation is a simple definition of the nodes and their limits/capacities. The node names are put into lists, and their associated capacities are put into dictionaries with the node names as the reference keys:
 
 .. literalinclude:: ../../../examples/BeerDistributionProblem.py
-    :lines: 10-25
+    :lines: 10-26
 
 The cost data is then inputted into a list, with two sub lists: the first 
 containing the costs of shipping from Warehouse A, and the second containing the 
@@ -160,36 +160,36 @@ warehouse A to bar 1, 2. If `costs["C"]["2"]` is called, it will return 0, since
 this is the defined default.
 
 .. literalinclude:: ../../../examples/BeerDistributionProblem.py
-    :lines: 27-35
+    :lines: 28-36
 
 The `prob` variable is created using the `LpProblem` function, with the usual 
 input parameters.
 
 .. literalinclude:: ../../../examples/BeerDistributionProblem.py
-    :lines: 37-38
+    :lines: 38-39
 
 A list of tuples is created containing all the arcs.
 
 .. literalinclude:: ../../../examples/BeerDistributionProblem.py
-    :lines: 40-41
+    :lines: 41-42
 
-A dictionary called `route_var` is created which contains the LP variables. The 
+A dictionary called `vars` is created which contains the LP variables. The
 reference keys to the dictionary are the warehouse name, then the bar 
 name(`["A"]["2"]`) , and the data is `Route_Tuple`. (e.g. `["A"]["2"]`: 
 Route_A_2). The lower limit of zero is set, the upper limit of `None` is set, 
 and the variables are defined to be Integers.
 
 .. literalinclude:: ../../../examples/BeerDistributionProblem.py
-    :lines: 43-44
+    :lines: 44-45
 
 The objective function is added to the variable `prob` using a list 
-comprehension. Since `route_vars` and `costs` are now dictionaries (with further 
+comprehension. Since `vars` and `costs` are now dictionaries (with further
 internal dictionaries), they can be used as if they were tables, as `for (w,b) 
 in Routes` will cycle through all the combinations/arcs. Note that `i` and `j` 
 could have been used, but `w` and `b` are more meaningful.
 
 .. literalinclude:: ../../../examples/BeerDistributionProblem.py
-    :lines: 46-47
+    :lines: 47-51
 
 The supply and demand constraints are added using a normal `for` loop and a list 
 comprehension. Supply Constraints: For each warehouse in turn, the values of the 
@@ -200,7 +200,7 @@ variables (number on arc) from each of the warehouses is summed, and then
 constrained to being greater than or equal to the demand minimum.
 
 .. literalinclude:: ../../../examples/BeerDistributionProblem.py
-    :lines: 49-55
+    :lines: 53-65
 
 Following this is the `prob.writeLP` line, and the rest as explained in previous 
 examples.
@@ -242,7 +242,7 @@ constraints all operated on the original supply, demand and cost
 lists/dictionaries, the only changes that must be made to include another demand node are:
 
 .. literalinclude:: ../../../examples/BeerDistributionProblemWarehouseExtension.py
-    :lines: 11-31
+    :lines: 11-25
 
 
 The `Bars` list is expanded and the `Demand` dictionary is expanded to make the 

--- a/doc/source/CaseStudies/a_two_stage_production_planning_problem.rst
+++ b/doc/source/CaseStudies/a_two_stage_production_planning_problem.rst
@@ -25,7 +25,7 @@ The uncertainty is expressed as one of four possible scenarios, each with equal 
 We begin by importing the `PuLP` package.
 
 .. literalinclude:: ../../../examples/Two_stage_Stochastic_GemstoneTools.py
-    :lines: 29-31
+    :lines: 30
 
 Next, we will read in the data.  Here, we read in the data as vectors.
 In actual use, this may be read from databases.  First, the data
@@ -57,20 +57,20 @@ To define our decision variables, we use the function `pulp.LpVariable.dicts()`,
 which creates dictionaries with associated indexing values.
 
 .. literalinclude:: ../../../examples/Two_stage_Stochastic_GemstoneTools.py
-    :lines: 61-63
+    :lines: 61-64
 
 
 We create the :class:`~pulp.LpProblem` and then make the objective function.
 Note that this is a maximization problem, as the goal is to maximize net revenue.
 
 .. literalinclude:: ../../../examples/Two_stage_Stochastic_GemstoneTools.py
-    :lines: 66
+    :lines: 67
 
 The objective function is specified using the `pulp.lpSum()` function. Note
 that it is added to the problem using `+=`.
 
 .. literalinclude:: ../../../examples/Two_stage_Stochastic_GemstoneTools.py
-    :lines: 69-72
+    :lines: 70-79
 
 We then add in constraints.  Constraints here in sets based on scenarios
 and products and are specified using the `for i in list:` notation.
@@ -81,7 +81,7 @@ Finally, here, the file gives each constraint a name which includes the specific
 scenario or product the constraint applies to.
 
 .. literalinclude:: ../../../examples/Two_stage_Stochastic_GemstoneTools.py
-    :lines: 73-85
+    :lines: 81-94
 
 
 The full file can be found here :download:`Two_stage_Stochastic_GemstoneTools.py <../../../examples/Two_stage_Stochastic_GemstoneTools.py>`


### PR DESCRIPTION
https://github.com/coin-or/pulp/pull/430 performed reformatting on code that were imported by line references into the documentation. This PR updates the line references to match the new code.