### PR TITLE
HiGHS: unknown option 'write_solution_pretty'

### DIFF
--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -83,7 +83,7 @@ class HiGHS_CMD(LpSolver_CMD):
         write_lines = [
             "solution_file = %s\n" % tmpSol,
             "write_solution_to_file = true\n",
-            "write_solution_style = 1\n",
+            "write_solution_style = 2\n",
         ]
         with open(tmpOptions, "w") as fp:
             fp.writelines(write_lines)

--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -83,7 +83,7 @@ class HiGHS_CMD(LpSolver_CMD):
         write_lines = [
             "solution_file = %s\n" % tmpSol,
             "write_solution_to_file = true\n",
-            "write_solution_pretty = true\n",
+            "write_solution_style = 1\n",
         ]
         with open(tmpOptions, "w") as fp:
             fp.writelines(write_lines)


### PR DESCRIPTION
I tried to use PuLP (current master) with the HiGHS solver and it always failed. Turns out that the option 'write_solution_pretty' is not supported. According to `https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.set` (referenced on the website), `write_solution_style` with value `1` should be used.