### PR TITLE
Fixed error when PATH is not set

### DIFF
--- a/pulp/apis/core.py
+++ b/pulp/apis/core.py
@@ -494,7 +494,7 @@ class LpSolver_CMD(LpSolver):
         if os.path.isabs(command):
             if os.path.exists(command) and os.access(command, os.X_OK):
                 return command
-        for path in os.environ.get("PATH", []).split(os.pathsep):
+        for path in os.environ.get("PATH", "").split(os.pathsep):
             new_path = os.path.join(path, command)
             if os.path.exists(new_path) and os.access(new_path, os.X_OK):
                 return os.path.join(path, command)


### PR DESCRIPTION
Default for a missing `PATH` should be an empty string, not an empty list. Otherwise trying to call `.split` on it will throw `AttributeError: 'list' object has no attribute 'split'`