### PR TITLE
Extend Cplex python API, introduce MST cplex files and logic to keep track of best bound

### DIFF
--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -542,6 +542,7 @@ class CPLEX_PY(LpSolver):
             con_names = [con for con in lp.constraints]
             try:
                 objectiveValue = lp.solverModel.solution.get_objective_value()
+                lp.assignBestBound(lp.solverModel.solution.MIP.get_best_objective())
                 variablevalues = dict(
                     zip(var_names, lp.solverModel.solution.get_values(var_names))
                 )

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -294,7 +294,7 @@ class CPLEX_PY(LpSolver):
             warmStart=False,
             solutionFile=None,
             logPath=None,
-            nthreads=0,
+            threads=0,
             epgap=None,
             logfilename=None
         ):
@@ -306,7 +306,7 @@ class CPLEX_PY(LpSolver):
             :param bool warmStart: if True, the solver will use the current value of variables as a start
             :param str solutionFile: if warmStart is True, you can specify a mst file that will be feed to the Cplex over the current values, at the end of the execution it will also save the final .mst file
             :param str logPath: path to the log file
-            :param int nthreads: number of threads to be used by CPLEX to solve a problem (default 0 uses all available)
+            :param int threads: number of threads to be used by CPLEX to solve a problem (default 0 uses all available)
             :param float epgap: deprecated for gapRel
             :param str logfilename: deprecated for logPath
             """
@@ -451,7 +451,7 @@ class CPLEX_PY(LpSolver):
                 self.changeEpgap(gapRel)
             if self.timeLimit is not None:
                 self.setTimeLimit(self.timeLimit)
-            self.setThreads(self.nthreads)
+            self.setThreads(self.threads)
             if self.optionsDict.get("warmStart", False):
                 # We assume "auto" for the effort_level
                 effort = self.solverModel.MIP_starts.effort_level.auto
@@ -482,11 +482,11 @@ class CPLEX_PY(LpSolver):
             self.solverModel.set_warning_stream(fileobj)
             self.solverModel.set_results_stream(fileobj)
 
-        def setThreads(self, nthreads=0):
+        def setThreads(self, threads=0):
             """
             Change cplex thread count used (0 is default which uses all available resources)
             """
-            self.solverModel.parameters.threads.set(nthreads)
+            self.solverModel.parameters.threads.set(threads)
 
         def changeEpgap(self, epgap=10**-4):
             """

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -293,8 +293,9 @@ class CPLEX_PY(LpSolver):
             gapRel=None,
             warmStart=False,
             logPath=None,
+            nthreads=0,
             epgap=None,
-            logfilename=None,
+            logfilename=None
         ):
             """
             :param bool mip: if False, assume LP even if integer variables
@@ -303,6 +304,7 @@ class CPLEX_PY(LpSolver):
             :param float gapRel: relative gap tolerance for the solver to stop (in fraction)
             :param bool warmStart: if True, the solver will use the current value of variables as a start
             :param str logPath: path to the log file
+            :param int nthreads: number of threads to be used by CPLEX to solve a problem (default 0 uses all available)
             :param float epgap: deprecated for gapRel
             :param str logfilename: deprecated for logPath
             """
@@ -447,6 +449,7 @@ class CPLEX_PY(LpSolver):
                 self.changeEpgap(gapRel)
             if self.timeLimit is not None:
                 self.setTimeLimit(self.timeLimit)
+            self.setThreads(self.nthreads)
             if self.optionsDict.get("warmStart", False):
                 # We assume "auto" for the effort_level
                 effort = self.solverModel.MIP_starts.effort_level.auto
@@ -469,6 +472,12 @@ class CPLEX_PY(LpSolver):
             self.solverModel.set_log_stream(fileobj)
             self.solverModel.set_warning_stream(fileobj)
             self.solverModel.set_results_stream(fileobj)
+
+        def setThreads(self, nthreads=0):
+            """
+            Change cplex thread count used (0 is default which uses all available resources)
+            """
+            self.solverModel.parameters.threads.set(nthreads)
 
         def changeEpgap(self, epgap=10**-4):
             """

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -1369,6 +1369,7 @@ class LpProblem(object):
         self.dummyVar = None
         self.solutionTime = 0
         self.solutionCpuTime = 0
+        self.bestBound=None # Variable to store the problem best bound when the solver exposes it
 
         # locals
         self.lastUnused = 0
@@ -1849,6 +1850,10 @@ class LpProblem(object):
             except KeyError:
                 pass
 
+    def assignBestBound(self, bestBound):
+        if bestBound:
+            self.bestBound=bestBound
+
     def assignConsSlack(self, values, activity=False):
         for name in values:
             try:
@@ -1861,6 +1866,8 @@ class LpProblem(object):
                     self.constraints[name].slack = float(values[name])
             except KeyError:
                 pass
+
+    
 
     def get_dummyVar(self):
         if self.dummyVar is None:

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -1369,7 +1369,7 @@ class LpProblem(object):
         self.dummyVar = None
         self.solutionTime = 0
         self.solutionCpuTime = 0
-        self.bestBound=None # Variable to store the problem best bound when the solver exposes it
+        self.bestBound = None  # Variable to store the problem best bound when the solver exposes it
 
         # locals
         self.lastUnused = 0
@@ -1852,7 +1852,7 @@ class LpProblem(object):
 
     def assignBestBound(self, bestBound):
         if bestBound:
-            self.bestBound=bestBound
+            self.bestBound = bestBound
 
     def assignConsSlack(self, values, activity=False):
         for name in values:
@@ -1866,8 +1866,6 @@ class LpProblem(object):
                     self.constraints[name].slack = float(values[name])
             except KeyError:
                 pass
-
-    
 
     def get_dummyVar(self):
         if self.dummyVar is None:


### PR DESCRIPTION
In this pull request I introduced the following changes:

- Extend the CPLEX python API to support the nthreads parameters - This would allow developers to control the CPU usage of Cplex within Pulp
- Created support to use MST cplex solution files which provide more information when using warmStarts by keeping track of multiple solutions 
- Introduced the bestbound parameters in the LP problem - This would allow to measure the gap of the problem when a timelimit is applied and create additional logic with it
