### PR TITLE
Xpress: flush after writing commands to stdin

### DIFF
--- a/pulp/apis/xpress_api.py
+++ b/pulp/apis/xpress_api.py
@@ -145,6 +145,7 @@ class XPRESS(LpSolver_CMD):
             xpress.stdin.write("GLOBAL\n")
         xpress.stdin.write("WRITEPRTSOL " + tmpSol + "\n")
         xpress.stdin.write("QUIT\n")
+        xpress.stdin.flush()
         if xpress.wait() != 0:
             raise PulpSolverError("PuLP: Error while executing " + self.path)
         status, values = self.readsol(tmpSol)


### PR DESCRIPTION
Fixes #505. Xpress was hanging because it was waiting for input. The commands written to it by PuLP were being buffered. Flushing the stream after writing the commands fixes the problem.