### PR TITLE
Xpress: quote paths properly for Tcl shell

### DIFF
--- a/pulp/apis/xpress_api.py
+++ b/pulp/apis/xpress_api.py
@@ -200,4 +200,4 @@ class XPRESS(LpSolver_CMD):
         double quotes and escaping the following characters, which would
         otherwise be interpreted by the Tcl shell: \ $ " { [
         """
-        return '"' + re.sub(r'([\\$"{[])', r'\\\1', path) + '"'
+        return '"' + re.sub(r'([\\$"{[])', r"\\\1", path) + '"'


### PR DESCRIPTION
An improvement to https://github.com/coin-or/pulp/pull/549. This ensures that any filename will be properly quoted before being passed to the Xpress console optimizer. My earlier approach to path quoting did not properly handle curly brackets within filenames.