### PR TITLE
Add support for MaxNode option with CBC solver

### DIFF
--- a/pulp/apis/coin_api.py
+++ b/pulp/apis/coin_api.py
@@ -52,6 +52,7 @@ class COIN_CMD(LpSolver_CMD):
         maxSeconds=None,
         gapRel=None,
         gapAbs=None,
+        maxNodes=None,
         presolve=None,
         cuts=None,
         strong=None,
@@ -70,6 +71,7 @@ class COIN_CMD(LpSolver_CMD):
         :param float timeLimit: maximum time for solver (in seconds)
         :param float gapRel: relative gap tolerance for the solver to stop (in fraction)
         :param float gapAbs: absolute gap tolerance for the solver to stop
+        :param int maxNodes: limit of nodes computed before solver stops
         :param int threads: sets the maximum number of threads
         :param list options: list of additional options to pass to solver
         :param bool warmStart: if True, the solver will use the current value of variables as a start
@@ -113,6 +115,7 @@ class COIN_CMD(LpSolver_CMD):
             mip=mip,
             msg=msg,
             timeLimit=timeLimit,
+            maxNodes=maxNodes,
             presolve=presolve,
             cuts=cuts,
             strong=strong,
@@ -167,6 +170,8 @@ class COIN_CMD(LpSolver_CMD):
             cmds += "mips {} ".format(tmpMst)
         if self.timeLimit is not None:
             cmds += "sec %s " % self.timeLimit
+        if self.maxNodes is not None:
+            cmds += "maxNodes %s " % self.maxNodes
         options = self.options + self.getOptions()
         for option in options:
             cmds += option + " "
@@ -373,6 +378,7 @@ class PULP_CBC_CMD(COIN_CMD):
             mip=True,
             msg=True,
             timeLimit=None,
+            maxNodes=None,
             fracGap=None,
             maxSeconds=None,
             gapRel=None,
@@ -398,6 +404,7 @@ class PULP_CBC_CMD(COIN_CMD):
                 mip=mip,
                 msg=msg,
                 timeLimit=timeLimit,
+                maxNodes=maxNodes,
                 fracGap=fracGap,
                 maxSeconds=maxSeconds,
                 gapRel=gapRel,

--- a/pulp/apis/core.py
+++ b/pulp/apis/core.py
@@ -203,7 +203,7 @@ class LpSolver:
     name = "LpSolver"
 
     def __init__(
-        self, mip=True, msg=True, options=None, timeLimit=None, *args, **kwargs
+        self, mip=True, msg=True, options=None, timeLimit=None, maxNodes=None, *args, **kwargs
     ):
         """
         :param bool mip: if False, assume LP even if integer variables
@@ -220,6 +220,7 @@ class LpSolver:
         self.msg = msg
         self.options = options
         self.timeLimit = timeLimit
+        self.maxNodes = maxNodes
 
         # this keeps the solver time in cpu time
         self.solution_time = 0

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -985,6 +985,28 @@ class BaseSolverTest:
                     {x: 4, y: -1, z: 6, w: 0},
                 )
 
+        def test_maxNodes(self):
+            name = self._testMethodName
+            prob = LpProblem(name, const.LpMinimize)
+            x = LpVariable("x", 0, 10)
+            y = LpVariable("y", -10, 10)
+            z = LpVariable("z", 0)
+            w = LpVariable("w", 0)
+            prob += x * 2 + y * 3 + z, "obj"
+            prob += x + y <= 10, "c1"
+            prob += x + z >= 10, "c2"
+            prob += -y + z == 7, "c3"
+            prob += w >= 0, "c4"
+            self.solver.maxNodes = 20  # Should not reach this node limit, just check it is implemented
+            print("\t Testing maxNodes argument")
+            if self.solver.name in ["PULP_CBC_CMD"]:
+                pulpTestCheck(
+                    prob,
+                    self.solver,
+                    [const.LpStatusOptimal],
+                    {x: 10, y: -7, z: 0, w: 0},
+                )
+
         def test_assignInvalidStatus(self):
             print("\t Testing invalid status")
             t = LpProblem("test")


### PR DESCRIPTION
This commit adds support for the `maxNodes` option for the CBC solver. Includes a simple test to make sure the option is implemented correctly.

I originally tried to create a test to show that using the `maxNodes` option would cause the CBC solver to terminate upon reaching that number of nodes, but couldn't find an intuitive way to read the `Enumerated Nodes` or "stopping reason" outputs of the sovler in test cases.