### PR TITLE
Remove unnecessary status print

### DIFF
--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -560,8 +560,6 @@ class CPLEX_PY(LpSolver):
                 pass
             # put pi and slack variables against the constraints
             # TODO: clear up the name of self.n2c
-            if self.msg:
-                print("Cplex status=", lp.cplex_status)
             lp.resolveOK = True
             for var in lp._variables:
                 var.isModified = False


### PR DESCRIPTION
Hello, 
I'm sorry for not opening an issue before submitting a PR since it is just a trivial matter.

When using the CPLEX_PY solver interface, there is an unsolicited print message that can't be deactivated.

**The problem is that it messes up with log messages**. I think it is most likely a forgotten debug print that was left in the code.

In my opinion, if one wants to check a solution status, one can directly print the `status` attribute:

```python
...
# The status of the solution is printed to the screen
print("Status:", plp.LpStatus[prob.status])
...
```

Like described in the examples.

Please let me know what you think,
thanks !
