### PR TITLE
Gurobipy Environment Handling

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,6 +26,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
+      - name: Install gurobipy
+        run: |
+          python -m pip install gurobipy
       - name: Install highspy
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
         run: |

--- a/pulp/apis/__init__.py
+++ b/pulp/apis/__init__.py
@@ -142,10 +142,13 @@ def listSolvers(onlyAvailable=False):
     :return: list of solver names
     :rtype: list
     """
-    solvers = [s() for s in _all_solvers]
-    if onlyAvailable:
-        return [solver.name for solver in solvers if solver.available()]
-    return [solver.name for solver in solvers]
+    result = []
+    for s in _all_solvers:
+        solver = s()
+        if (not onlyAvailable) or solver.available():
+            result.append(solver.name)
+        del solver
+    return result
 
 
 # DEPRECATED aliases:

--- a/pulp/apis/gurobi_api.py
+++ b/pulp/apis/gurobi_api.py
@@ -170,6 +170,7 @@ class GUROBI(LpSolver):
                 if self.manage_env:
                     self.env_options["OutputFlag"] = 0
                 else:
+                    self.env_options["OutputFlag"] = 0
                     self.solver_params["OutputFlag"] = 0
 
         def __del__(self):
@@ -240,7 +241,7 @@ class GUROBI(LpSolver):
         def available(self):
             """True if the solver is available"""
             try:
-                with gp.Env():
+                with gp.Env(params=self.env_options):
                     pass
             except gurobipy.GurobiError as e:
                 warnings.warn(f"GUROBI error: {e}.")

--- a/pulp/apis/gurobi_api.py
+++ b/pulp/apis/gurobi_api.py
@@ -199,22 +199,12 @@ class GUROBI(LpSolver):
 
         def available(self):
             """True if the solver is available"""
-            self.initGurobi()
-            m = self.model.copy()
-            m.setParam("OutputFlag", 0)
             try:
-                m.addVars(range(2001))
-                m.setParam("OutputFlag", 0)
-                m.optimize()
-            except gp.GurobiError as e:
+                with gp.Env():
+                    pass
+            except gurobipy.GurobiError as e:
                 warnings.warn("GUROBI error: {}.".format(e))
                 return False
-            finally:
-                m.dispose()
-            # If user is handling environment, make sure we still set parameters
-            if not self.manage_env and self.env_options:
-                for param, value in self.env_options:
-                    self.model.setParam(param, value)
             return True
 
         def initGurobi(self):

--- a/pulp/tests/run_tests.py
+++ b/pulp/tests/run_tests.py
@@ -1,6 +1,6 @@
 import unittest
 import pulp
-from pulp.tests import test_pulp, test_examples
+from pulp.tests import test_pulp, test_examples, test_gurobipy_env
 
 
 def pulpTestAll(test_docs=False):
@@ -19,6 +19,9 @@ def get_test_suite(test_docs=False):
     # we get suite with all PuLP tests
     pulp_solver_tests = loader.loadTestsFromModule(test_pulp)
     suite_all.addTests(pulp_solver_tests)
+    # Add tests for gurobipy env
+    gurobipy_env = loader.loadTestsFromModule(test_gurobipy_env)
+    suite_all.addTests(gurobipy_env)
     # We add examples and docs tests
     if test_docs:
         docs_examples = loader.loadTestsFromTestCase(test_examples.Examples_DocsTests)

--- a/pulp/tests/test_gurobipy_env.py
+++ b/pulp/tests/test_gurobipy_env.py
@@ -1,0 +1,36 @@
+import unittest
+
+from pulp import GUROBI, LpProblem, LpVariable, const
+
+
+class GurobiEnvTests(unittest.TestCase):
+    def setUp(self):
+        self.options = {"OutputFlag": 1, "MemLimit": 1}
+        self.prob = LpProblem("test011", const.LpMaximize)
+        x = LpVariable("x", 0, 1)
+        y = LpVariable("y", 0, 1)
+        z = LpVariable("z", 0, 1)
+        self.prob += x + y + z, "obj"
+        self.prob += x + y + z <= 1, "c1"
+
+    def testContextManager(self):
+        # Using solver within a context manager
+        with GUROBI(msg=True, **self.options) as solver:
+            status = self.prob.solve(solver)
+
+    def testGpEnv(self):
+        # Using gp.Env within a context manager
+        import gurobipy as gp
+
+        with gp.Env() as env:
+            solver = GUROBI(msg=True, manageEnv=False, env=env, **self.options)
+            self.prob.solve(solver)
+
+    def testDefault(self):
+        solver = GUROBI(msg=True, **self.options)
+        self.prob.solve(solver)
+
+    def testNoEnv(self):
+        # Failing test for no environment handling
+        solver = GUROBI(msg=True, manageEnv=False, envOptions=self.options)
+        self.assertRaises(AttributeError, self.prob.solve, solver)

--- a/pulp/tests/test_gurobipy_env.py
+++ b/pulp/tests/test_gurobipy_env.py
@@ -2,7 +2,7 @@ import unittest
 
 import gurobipy as gp
 
-from pulp import GUROBI, GUROBI_CMD, LpProblem, LpVariable, const
+from pulp import GUROBI, LpProblem, LpVariable, const
 
 
 def check_dummy_env():

--- a/pulp/tests/test_gurobipy_env.py
+++ b/pulp/tests/test_gurobipy_env.py
@@ -10,7 +10,7 @@ except ImportError:
 
 
 def check_dummy_env():
-    with gp.Env():
+    with gp.Env(params={"OutputFlag": 0}):
         pass
 
 
@@ -28,14 +28,14 @@ class GurobiEnvTests(unittest.TestCase):
     def setUp(self):
         if gp is None:
             self.skipTest("Skipping all tests in test_gurobipy_env.py")
-        self.options = {"OutputFlag": 0}
-        self.env_options = {"MemLimit": 1}
+        self.options = {"Method": 0}
+        self.env_options = {"MemLimit": 1, "OutputFlag": 0}
 
     def test_gp_env(self):
         # Using gp.Env within a context manager
         with gp.Env(params=self.env_options) as env:
             prob = generate_lp()
-            solver = GUROBI(env=env, **self.options)
+            solver = GUROBI(msg=False, env=env, **self.options)
             prob.solve(solver)
             solver.close()
         check_dummy_env()
@@ -45,19 +45,19 @@ class GurobiEnvTests(unittest.TestCase):
         # Not closing results in an error for a single use license.
         with gp.Env(params=self.env_options) as env:
             prob = generate_lp()
-            solver = GUROBI(env=env, **self.options)
+            solver = GUROBI(msg=False, env=env, **self.options)
             prob.solve(solver)
         self.assertRaises(gp.GurobiError, check_dummy_env)
 
     def test_multiple_gp_env(self):
         # Using the same env multiple times
-        with gp.Env() as env:
-            solver = GUROBI(env=env)
+        with gp.Env(params=self.env_options) as env:
+            solver = GUROBI(msg=False, env=env)
             prob = generate_lp()
             prob.solve(solver)
             solver.close()
 
-            solver2 = GUROBI(env=env)
+            solver2 = GUROBI(msg=False, env=env)
             prob2 = generate_lp()
             prob2.solve(solver2)
             solver2.close()
@@ -71,7 +71,7 @@ class GurobiEnvTests(unittest.TestCase):
         freed. On a single-use license this passes (fails to initialise a dummy
         env).
         """
-        solver = GUROBI(**self.options)
+        solver = GUROBI(msg=False, **self.options)
         prob = generate_lp()
         prob.solve(solver)
 
@@ -80,7 +80,7 @@ class GurobiEnvTests(unittest.TestCase):
         solver.close()
 
     def test_manage_env(self):
-        solver = GUROBI(manageEnv=True, **self.options)
+        solver = GUROBI(msg=False, manageEnv=True, **self.options)
         prob = generate_lp()
         prob.solve(solver)
 
@@ -88,14 +88,14 @@ class GurobiEnvTests(unittest.TestCase):
         check_dummy_env()
 
     def test_multiple_solves(self):
-        solver = GUROBI(manageEnv=True, **self.options)
+        solver = GUROBI(msg=False, manageEnv=True, **self.options)
         prob = generate_lp()
         prob.solve(solver)
 
         solver.close()
         check_dummy_env()
 
-        solver2 = GUROBI(manageEnv=True, **self.options)
+        solver2 = GUROBI(msg=False, manageEnv=True, **self.options)
         prob.solve(solver2)
 
         solver2.close()
@@ -108,14 +108,14 @@ class GurobiEnvTests(unittest.TestCase):
         single-use license this passes (fails to initialise a dummy env with a
         memory leak).
         """
-        solver = GUROBI(**self.options)
+        solver = GUROBI(msg=False, **self.options)
         prob = generate_lp()
         prob.solve(solver)
 
         tmp = solver.model
         solver.close()
 
-        solver2 = GUROBI(**self.options)
+        solver2 = GUROBI(msg=False, **self.options)
 
         prob2 = generate_lp()
         prob2.solve(solver2)

--- a/pulp/tests/test_gurobipy_env.py
+++ b/pulp/tests/test_gurobipy_env.py
@@ -1,8 +1,12 @@
 import unittest
 
-import gurobipy as gp
-
 from pulp import GUROBI, LpProblem, LpVariable, const
+
+try:
+    import gurobipy as gp
+    from gurobipy import GRB
+except ImportError:
+    gp = None
 
 
 def check_dummy_env():
@@ -22,14 +26,16 @@ def generate_lp() -> LpProblem:
 
 class GurobiEnvTests(unittest.TestCase):
     def setUp(self):
-        self.options = {"OutputFlag": 1}
+        if gp is None:
+            self.skipTest("Skipping all tests in test_gurobipy_env.py")
+        self.options = {"OutputFlag": 0}
         self.env_options = {"MemLimit": 1}
 
     def test_gp_env(self):
         # Using gp.Env within a context manager
         with gp.Env(params=self.env_options) as env:
             prob = generate_lp()
-            solver = GUROBI(msg=True, env=env, **self.options)
+            solver = GUROBI(env=env, **self.options)
             prob.solve(solver)
             solver.close()
         check_dummy_env()
@@ -39,19 +45,19 @@ class GurobiEnvTests(unittest.TestCase):
         # Not closing results in an error for a single use license.
         with gp.Env(params=self.env_options) as env:
             prob = generate_lp()
-            solver = GUROBI(msg=True, env=env, **self.options)
+            solver = GUROBI(env=env, **self.options)
             prob.solve(solver)
         self.assertRaises(gp.GurobiError, check_dummy_env)
 
     def test_multiple_gp_env(self):
         # Using the same env multiple times
         with gp.Env() as env:
-            solver = GUROBI(msg=True, env=env)
+            solver = GUROBI(env=env)
             prob = generate_lp()
             prob.solve(solver)
             solver.close()
 
-            solver2 = GUROBI(msg=True, env=env)
+            solver2 = GUROBI(env=env)
             prob2 = generate_lp()
             prob2.solve(solver2)
             solver2.close()
@@ -65,7 +71,7 @@ class GurobiEnvTests(unittest.TestCase):
         freed. On a single-use license this passes (fails to initialise a dummy
         env).
         """
-        solver = GUROBI(msg=True, **self.options)
+        solver = GUROBI(**self.options)
         prob = generate_lp()
         prob.solve(solver)
 
@@ -74,7 +80,7 @@ class GurobiEnvTests(unittest.TestCase):
         solver.close()
 
     def test_manage_env(self):
-        solver = GUROBI(msg=True, manageEnv=True, **self.options)
+        solver = GUROBI(manageEnv=True, **self.options)
         prob = generate_lp()
         prob.solve(solver)
 
@@ -82,14 +88,14 @@ class GurobiEnvTests(unittest.TestCase):
         check_dummy_env()
 
     def test_multiple_solves(self):
-        solver = GUROBI(msg=True, manageEnv=True, **self.options)
+        solver = GUROBI(manageEnv=True, **self.options)
         prob = generate_lp()
         prob.solve(solver)
 
         solver.close()
         check_dummy_env()
 
-        solver2 = GUROBI(msg=True, manageEnv=True, **self.options)
+        solver2 = GUROBI(manageEnv=True, **self.options)
         prob.solve(solver2)
 
         solver2.close()
@@ -102,14 +108,14 @@ class GurobiEnvTests(unittest.TestCase):
         single-use license this passes (fails to initialise a dummy env with a
         memory leak).
         """
-        solver = GUROBI(msg=True, **self.options)
+        solver = GUROBI(**self.options)
         prob = generate_lp()
         prob.solve(solver)
 
         tmp = solver.model
         solver.close()
 
-        solver2 = GUROBI(msg=True, **self.options)
+        solver2 = GUROBI(**self.options)
 
         prob2 = generate_lp()
         prob2.solve(solver2)

--- a/pulp/tests/test_gurobipy_env.py
+++ b/pulp/tests/test_gurobipy_env.py
@@ -2,7 +2,6 @@ import unittest
 
 import gurobipy as gp
 
-
 from pulp import GUROBI, GUROBI_CMD, LpProblem, LpVariable, const
 
 
@@ -34,6 +33,15 @@ class GurobiEnvTests(unittest.TestCase):
             prob.solve(solver)
             solver.close()
         check_dummy_env()
+
+    @unittest.SkipTest
+    def test_gp_env_no_close(self):
+        # Not closing results in an error for a single use license.
+        with gp.Env(params=self.env_options) as env:
+            prob = generate_lp()
+            solver = GUROBI(msg=True, env=env, **self.options)
+            prob.solve(solver)
+        self.assertRaises(gp.GurobiError, check_dummy_env)
 
     def test_multiple_gp_env(self):
         # Using the same env multiple times

--- a/pulp/tests/test_gurobipy_env.py
+++ b/pulp/tests/test_gurobipy_env.py
@@ -26,7 +26,7 @@ class GurobiEnvTests(unittest.TestCase):
         self.options = {"OutputFlag": 1}
         self.env_options = {"MemLimit": 1}
 
-    def testGpEnv(self):
+    def test_gp_env(self):
         # Using gp.Env within a context manager
         with gp.Env(params=self.env_options) as env:
             prob = generate_lp()
@@ -35,7 +35,7 @@ class GurobiEnvTests(unittest.TestCase):
             solver.close()
         check_dummy_env()
 
-    def testMultipleGpEnv(self):
+    def test_multiple_gp_env(self):
         # Using the same env multiple times
         with gp.Env() as env:
             solver = GUROBI(msg=True, env=env)
@@ -51,7 +51,7 @@ class GurobiEnvTests(unittest.TestCase):
         check_dummy_env()
 
     @unittest.SkipTest
-    def testBackwardCompatibility(self):
+    def test_backward_compatibility(self):
         """
         Backward compatibility check as previously the environment was not being
         freed. On a single-use license this passes (fails to initialise a dummy
@@ -65,7 +65,7 @@ class GurobiEnvTests(unittest.TestCase):
         gp.disposeDefaultEnv()
         solver.close()
 
-    def testManageEnvTrue(self):
+    def test_manage_env(self):
         solver = GUROBI(msg=True, manageEnv=True, **self.options)
         prob = generate_lp()
         prob.solve(solver)
@@ -73,7 +73,7 @@ class GurobiEnvTests(unittest.TestCase):
         solver.close()
         check_dummy_env()
 
-    def testMultipleSolves(self):
+    def test_multiple_solves(self):
         solver = GUROBI(msg=True, manageEnv=True, **self.options)
         prob = generate_lp()
         prob.solve(solver)
@@ -88,7 +88,7 @@ class GurobiEnvTests(unittest.TestCase):
         check_dummy_env()
 
     @unittest.SkipTest
-    def testLeak(self):
+    def test_leak(self):
         """
         Check that we cannot initialise environments after a memory leak. On a
         single-use license this passes (fails to initialise a dummy env with a

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -1254,9 +1254,15 @@ class BaseSolverTest:
             prob += -y + z == 7, "c3"
             prob += w >= 0, "c4"
             print("\t Testing invalid var names")
-            pulpTestCheck(
-                prob, self.solver, [const.LpStatusOptimal], {x: 4, y: -1, z: 6, w: 0}
-            )
+            if self.solver.name not in [
+                "GUROBI_CMD",  # end is a key-word for LP files
+            ]:
+                pulpTestCheck(
+                    prob,
+                    self.solver,
+                    [const.LpStatusOptimal],
+                    {x: 4, y: -1, z: 6, w: 0},
+                )
 
         def test_LpVariable_indexs_param(self):
             """

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -1211,7 +1211,12 @@ class BaseSolverTest:
 
             time_limit = 10
             solver_settings = dict(
-                PULP_CBC_CMD=30, COIN_CMD=30, SCIP_CMD=30, GUROBI_CMD=50, CPLEX_CMD=50
+                PULP_CBC_CMD=30,
+                COIN_CMD=30,
+                SCIP_CMD=30,
+                GUROBI_CMD=50,
+                CPLEX_CMD=50,
+                GUROBI=50,
             )
             bins = solver_settings.get(self.solver.name)
             if bins is None:
@@ -1233,6 +1238,9 @@ class BaseSolverTest:
                 delta=delta,
                 msg="optimization time for solver {}".format(self.solver.name),
             )
+            self.assertTrue(prob.objective.value() is not None)
+            for v in prob.variables():
+                self.assertTrue(v.varValue is not None)
 
         def test_invalid_var_names(self):
             prob = LpProblem(self._testMethodName, const.LpMinimize)


### PR DESCRIPTION
- Fix coin-or/pulp/issues/586.
- For coin-or/pulp/issues/571
  - Fix issue with `pulp.list_solvers`. Cheers @simonbowly!
  - Added three new parameters to `GUROBI` that allow users more fine control over the environments used.
    - `env: gp.Env` users environment to use.
    - `envOptions: dict`, options to give to the environment if `manageEnv` is True.
    - `manageEnv: bool`: whether environments are handled internally or not default is false (as it was before).
   - Added a new function to free the environments and models properly `close`. If users are using their own environments or using `manageEnv=True`, they should always call this function afterwards.


Sample use: 
```python
# Pass environment as a parameter
with gp.Env(params=env_options) as env:
  prob = generate_lp()
  solver = GUROBI(msg=True, env=env, **solver_options)
  prob.solve(solver)
  # Dispose model (required to correctly free env)
  solver.close()
```

Or, 
```python
# Use manageEnv=True and pulp will take care
solver = GUROBI(msg=True, manageEnv=True, envOptions=env_options, **solver_options)
prob = generate_lp()
prob.solve(solver)
# Dispose env + model
solver.close()
```