### PR TITLE
Upgrade to Python 3.7+

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,18 +8,13 @@ jobs:
     strategy:
       max-parallel: 21
       matrix:
-        python-version: [2.7, 3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        exclude:
-          - os: macOS-latest
-            python-version: 2.7
-          - os: windows-latest
-            python-version: 2.7
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: install glpk
@@ -34,7 +29,6 @@ jobs:
       - name: Test with pulptest
         run: pulptest
       - name: Code Quality
-        if: ${{ matrix.python-version >= 3.6 }}
         run: |
           pip install black
           black pulp/ --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,8 @@ repos:
     rev: stable
     hooks:
     - id: black
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.1.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py37-plus]

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Examples
 
 See the examples directory for examples.
 
-PuLP requires Python 2.7 or Python >= 3.4.
+PuLP requires Python 3.7 or newer.
 
 The examples use the default solver (CBC). To use other solvers they must be available (installed and accessible). For more information on how to do that, see the `guide on configuring solvers <https://coin-or.github.io/pulp/guides/how_to_configure_solvers.html>`_.
 
@@ -106,8 +106,8 @@ Exported Functions:
 Building the documentation
 --------------------------
 
-The PuLP documentation is built with `Sphinx <https://www.sphinx-doc.org>`_.  We recommended using a 
-`virtual environment <https://docs.python.org/3/library/venv.html>`_ to build the documentation locally. 
+The PuLP documentation is built with `Sphinx <https://www.sphinx-doc.org>`_.  We recommended using a
+`virtual environment <https://docs.python.org/3/library/venv.html>`_ to build the documentation locally.
 
 To build, run the following in a terminal window, in the PuLP root directory
 
@@ -117,11 +117,11 @@ To build, run the following in a terminal window, in the PuLP root directory
     python -m pip install -r requirements-dev.txt
     cd doc
     make html
-	 
+
 A folder named html will be created inside the ``build/`` directory.
 The home page for the documentation is ``doc/build/html/index.html`` which can be opened in a browser.
 
-	 
+
 
 
 

--- a/doc/KPyCon2009/code/beerdistribution.py
+++ b/doc/KPyCon2009/code/beerdistribution.py
@@ -51,14 +51,14 @@ prob += sum([x[w][b] * costs[w][b] for (w, b) in routes]), "Sum_of_Transporting_
 for w in warehouses:
     prob += (
         sum([x[w][b] for b in bars]) <= supply[w],
-        "Sum_of_Products_out_of_Warehouse_%s" % w,
+        f"Sum_of_Products_out_of_Warehouse_{w}",
     )
 
 # Demand minimum constraints are added to prob for each demand node (bar)
 for b in bars:
     prob += (
         sum([x[w][b] for w in warehouses]) >= demand[b],
-        "Sum_of_Products_into_Bar%s" % b,
+        f"Sum_of_Products_into_Bar{b}",
     )
 
 # The problem data is written to an .lp file

--- a/doc/KPyCon2009/code/wedding.py
+++ b/doc/KPyCon2009/code/wedding.py
@@ -41,12 +41,12 @@ seating_model += (
 for guest in guests:
     seating_model += (
         sum([x[table] for table in possible_tables if guest in table]) == 1,
-        "Must_seat_%s" % guest,
+        f"Must_seat_{guest}",
     )
 
 seating_model.solve()
 
-print("The choosen tables are out of a total of %s:" % len(possible_tables))
+print(f"The choosen tables are out of a total of {len(possible_tables)}:")
 for table in possible_tables:
     if x[table].value() == 1.0:
         print(table)

--- a/doc/KPyCon2009/code/whiskas.py
+++ b/doc/KPyCon2009/code/whiskas.py
@@ -33,4 +33,6 @@ whiskas_model.solve()
 
 # print the result
 for ingredient in ingredients:
-    print("The mass of %s is %s grams per can" % (ingredient, x[ingredient].value()))
+    print(
+        "The mass of {} is {} grams per can".format(ingredient, x[ingredient].value())
+    )

--- a/doc/KPyCon2009/code/whiskas.py
+++ b/doc/KPyCon2009/code/whiskas.py
@@ -33,6 +33,4 @@ whiskas_model.solve()
 
 # print the result
 for ingredient in ingredients:
-    print(
-        "The mass of {} is {} grams per can".format(ingredient, x[ingredient].value())
-    )
+    print(f"The mass of {ingredient} is {x[ingredient].value()} grams per can")

--- a/doc/source/_static/plotter.py
+++ b/doc/source/_static/plotter.py
@@ -17,15 +17,15 @@ def plot_interval(a, c, x_left, x_right, i, fbound):
     text(
         (x_left + lh) / 2.0,
         0.1,
-        "freebound interval [{}, {}] is penalty-free".format(lh, rh),
+        f"freebound interval [{lh}, {rh}] is penalty-free",
     )
-    text((x_left + lh) / 2.0, 0.2, "rhs={},    {}".format(c, fbound))
+    text((x_left + lh) / 2.0, 0.2, f"rhs={c},    {fbound}")
     cur_ax = gca()
     cur_ax.add_patch(arrow_l)
     cur_ax.add_patch(arrow_r)
     axis([x_left, x_right, -0.1, 0.3])
     yticks([])
-    title(r"Elasticized constraint\_{}   $C(x)= {} $".format(i, c))
+    title(rf"Elasticized constraint\_{i}   $C(x)= {c} $")
 
 
 figure()
@@ -38,7 +38,7 @@ a = [0.01, 0.01]
 c = 200
 x_left = 0.97 * c
 x_right = 1.03 * c
-fb_string = "{}{} = {}".format(fbound, "", a[0])
+fb_string = f"{fbound} = {a[0]}"
 plot_interval(a, c, x_left, x_right, i, fb_string)
 
 i += 1
@@ -47,7 +47,7 @@ a = [0.02, 0.05]
 c = 500
 x_left = 0.9 * c  # scale of window
 x_right = 1.2 * c  # scale of window
-fb_string = "{}{} = [{},{}]".format(fbound, "List", a[0], a[1])
+fb_string = f"{fbound}List = [{a[0]},{a[1]}]"
 plot_interval(a, c, x_left, x_right, i, fb_string)
 savefig("freebound.jpg")
 savefig("freebound.pdf")

--- a/doc/source/_static/plotter.py
+++ b/doc/source/_static/plotter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
 
 from matplotlib import rc
 
@@ -18,15 +17,15 @@ def plot_interval(a, c, x_left, x_right, i, fbound):
     text(
         (x_left + lh) / 2.0,
         0.1,
-        "freebound interval [%s, %s] is penalty-free" % (lh, rh),
+        "freebound interval [{}, {}] is penalty-free".format(lh, rh),
     )
-    text((x_left + lh) / 2.0, 0.2, "rhs=%s,    %s" % (c, fbound))
+    text((x_left + lh) / 2.0, 0.2, "rhs={},    {}".format(c, fbound))
     cur_ax = gca()
     cur_ax.add_patch(arrow_l)
     cur_ax.add_patch(arrow_r)
     axis([x_left, x_right, -0.1, 0.3])
     yticks([])
-    title("Elasticized constraint\_%s   $C(x)= %s $" % (i, c))
+    title(r"Elasticized constraint\_{}   $C(x)= {} $".format(i, c))
 
 
 figure()
@@ -39,7 +38,7 @@ a = [0.01, 0.01]
 c = 200
 x_left = 0.97 * c
 x_right = 1.03 * c
-fb_string = "%s%s = %s" % (fbound, "", a[0])
+fb_string = "{}{} = {}".format(fbound, "", a[0])
 plot_interval(a, c, x_left, x_right, i, fb_string)
 
 i += 1
@@ -48,7 +47,7 @@ a = [0.02, 0.05]
 c = 500
 x_left = 0.9 * c  # scale of window
 x_right = 1.2 * c  # scale of window
-fb_string = "%s%s = [%s,%s]" % (fbound, "List", a[0], a[1])
+fb_string = "{}{} = [{},{}]".format(fbound, "List", a[0], a[1])
 plot_interval(a, c, x_left, x_right, i, fb_string)
 savefig("freebound.jpg")
 savefig("freebound.pdf")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # pulp sphinx documentation build configuration file, created by
 # sphinx-quickstart on Mon Nov  2 11:54:01 2009.

--- a/examples/AmericanSteelProblem.py
+++ b/examples/AmericanSteelProblem.py
@@ -89,7 +89,7 @@ for n in Nodes:
     prob += (
         supply[n] + lpSum([vars[(i, j)] for (i, j) in Arcs if j == n])
         >= demand[n] + lpSum([vars[(i, j)] for (i, j) in Arcs if i == n])
-    ), "Steel Flow Conservation in Node %s" % n
+    ), f"Steel Flow Conservation in Node {n}"
 
 # The problem data is written to an .lp file
 prob.writeLP("AmericanSteelProblem.lp")

--- a/examples/BeerDistributionProblem.py
+++ b/examples/BeerDistributionProblem.py
@@ -54,14 +54,14 @@ prob += (
 for w in Warehouses:
     prob += (
         lpSum([vars[w][b] for b in Bars]) <= supply[w],
-        "Sum_of_Products_out_of_Warehouse_%s" % w,
+        f"Sum_of_Products_out_of_Warehouse_{w}",
     )
 
 # The demand minimum constraints are added to prob for each demand node (bar)
 for b in Bars:
     prob += (
         lpSum([vars[w][b] for w in Warehouses]) >= demand[b],
-        "Sum_of_Products_into_Bar%s" % b,
+        f"Sum_of_Products_into_Bar{b}",
     )
 
 # The problem data is written to an .lp file

--- a/examples/BeerDistributionProblemCompetitorExtension.py
+++ b/examples/BeerDistributionProblemCompetitorExtension.py
@@ -53,14 +53,14 @@ prob += (
 for w in Warehouses:
     prob += (
         lpSum([vars[w][b] for b in Bars]) <= supply[w],
-        "Sum_of_Products_out_of_Warehouse_%s" % w,
+        f"Sum_of_Products_out_of_Warehouse_{w}",
     )
 
 # The demand minimum constraints are added to prob for each demand node (bar)
 for b in Bars:
     prob += (
         lpSum([vars[w][b] for w in Warehouses]) >= demand[b],
-        "Sum_of_Products_into_Bar%s" % b,
+        f"Sum_of_Products_into_Bar{b}",
     )
 
 # The problem data is written to an .lp file

--- a/examples/BeerDistributionProblemWarehouseExtension.py
+++ b/examples/BeerDistributionProblemWarehouseExtension.py
@@ -46,14 +46,14 @@ prob += (
 for w in Warehouses:
     prob += (
         lpSum([vars[w][b] for b in Bars]) <= supply[w],
-        "Sum_of_Products_out_of_Warehouse_%s" % w,
+        f"Sum_of_Products_out_of_Warehouse_{w}",
     )
 
 # The demand minimum constraints are added to prob for each demand node (bar)
 for b in Bars:
     prob += (
         lpSum([vars[w][b] for w in Warehouses]) >= demand[b],
-        "Sum_of_Products_into_Bar%s" % b,
+        f"Sum_of_Products_into_Bar{b}",
     )
 
 # The problem data is written to an .lp file

--- a/examples/BeerDistributionProblem_resolve.py
+++ b/examples/BeerDistributionProblem_resolve.py
@@ -55,7 +55,7 @@ prob += (
 for w in Warehouses:
     prob += (
         lpSum([vars[w][b] for b in Bars]) <= supply[w],
-        "Sum_of_Products_out_of_Warehouse_%s" % w,
+        f"Sum_of_Products_out_of_Warehouse_{w}",
     )
 
 # The demand minimum constraints are added to prob for each demand node (bar)
@@ -63,7 +63,7 @@ for w in Warehouses:
 bar_demand_constraint = {}
 for b in Bars:
     constraint = lpSum([vars[w][b] for w in Warehouses]) >= demand[b]
-    prob += constraint, "Sum_of_Products_into_Bar_%s" % b
+    prob += constraint, f"Sum_of_Products_into_Bar_{b}"
     bar_demand_constraint[b] = constraint
 
 # The problem data is written to an .lp file

--- a/examples/CG.py
+++ b/examples/CG.py
@@ -62,7 +62,7 @@ def masterSolve(Patterns, rollData, relax=True):
         prob += (
             lpSum([pattVars[i] * i.lengthsdict[j] for i in Patterns]) - surplusVars[j]
             >= rollDemand[j],
-            "Min%s" % j,
+            f"Min{j}",
         )
 
     # The problem is solved

--- a/examples/ComputerPlantProblem.py
+++ b/examples/ComputerPlantProblem.py
@@ -68,14 +68,14 @@ prob += (
 for p in Plants:
     prob += (
         lpSum([flow[p][s] for s in Stores]) <= supply[p] * build[p],
-        "Sum of Products out of Plant %s" % p,
+        f"Sum of Products out of Plant {p}",
     )
 
 # The Demand minimum constraints are added for each demand node (store)
 for s in Stores:
     prob += (
         lpSum([flow[p][s] for p in Plants]) >= demand[s],
-        "Sum of Products into Stores %s" % s,
+        f"Sum of Products into Stores {s}",
     )
 
 # The problem data is written to an .lp file

--- a/examples/SpongeRollProblem1.py
+++ b/examples/SpongeRollProblem1.py
@@ -38,7 +38,7 @@ prob += lpSum([vars[i] * cost for i in PatternNames]), "Production Cost"
 for i in LenOpts:
     prob += (
         lpSum([vars[j] * patterns[i][j] for j in PatternNames]) >= rollDemand[i],
-        "Ensuring enough %s cm rolls" % i,
+        f"Ensuring enough {i} cm rolls",
     )
 
 # The problem data is written to an .lp file

--- a/examples/SpongeRollProblem2.py
+++ b/examples/SpongeRollProblem2.py
@@ -60,7 +60,7 @@ for i in LenOpts:
     prob += (
         lpSum([pattVars[j] * patterns[i][j] for j in PatternNames]) - surplusVars[i]
         >= rollDemand[i],
-        "Ensuring enough %s cm rolls" % i,
+        f"Ensuring enough {i} cm rolls",
     )
 
 # The problem data is written to an .lp file

--- a/examples/SpongeRollProblem3.py
+++ b/examples/SpongeRollProblem3.py
@@ -65,9 +65,9 @@ def makePatterns(totalRollLength, lenOpts):
         trim[name] = totalRollLength - ssum
     # The different cutting lengths are printed, and the number of each roll of that length in each
     # pattern is printed below. This is so the user can see what each pattern contains.
-    print("Lens: %s" % lenOpts)
+    print(f"Lens: {lenOpts}")
     for name, pattern in zip(PatternNames, patterns):
-        print(name + "  = %s" % pattern)
+        print(name + f"  = {pattern}")
 
     return (PatternNames, patterns, trim)
 
@@ -129,7 +129,7 @@ for j in LenOpts:
     prob += (
         lpSum([pattVars[i] * patterns[i][j] for i in PatternNames]) - surplusVars[j]
         >= rollDemand[j],
-        "Ensuring enough %s cm rolls" % j,
+        f"Ensuring enough {j} cm rolls",
     )
 
 # The problem data is written to an .lp file

--- a/examples/SpongeRollProblem4.py
+++ b/examples/SpongeRollProblem4.py
@@ -63,7 +63,7 @@ def makePatterns(totalRollLength, lenOpts):
 
     # The different cutting lengths are printed, and the number of each roll of that length in each
     # pattern is printed below. This is so the user can see what each pattern contains.
-    print("Lens: %s" % lenOpts)
+    print(f"Lens: {lenOpts}")
     for i in Patterns:
         print(i, " = %s" % [i.lengthsdict[j] for j in lenOpts])
 
@@ -128,7 +128,7 @@ for j in Pattern.lenOpts:
     prob += (
         lpSum([pattVars[i] * i.lengthsdict[j] for i in Patterns]) - surplusVars[j]
         >= rollDemand[j],
-        "Ensuring enough %s cm rolls" % j,
+        f"Ensuring enough {j} cm rolls",
     )
 
 # The problem data is written to an .lp file

--- a/examples/Two_stage_Stochastic_GemstoneTools.py
+++ b/examples/Two_stage_Stochastic_GemstoneTools.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Author: Louis Luangkesorn <lugerpitt@gmail.com> 2019
 https://github.com/lluang
 

--- a/examples/furniture.py
+++ b/examples/furniture.py
@@ -21,7 +21,7 @@ prob += lpSum([costs[c] * vars[c] for c in Chairs])
 for r in Resources:
     prob += (
         lpSum([activity[r][c] * vars[c] for c in Chairs]) <= capacity[r],
-        "capacity_of_%s" % r,
+        f"capacity_of_{r}",
     )
 prob.writeLP("furniture.lp")
 prob.solve()

--- a/examples/test3.py
+++ b/examples/test3.py
@@ -113,10 +113,10 @@ print()
 
 for t in time:
     # Demand, hydro storage, hydro production
-    print("%5.1f" % demand[t], "%5.1f" % value(s[t]), "%5.1f" % value(ph[t]), end=" ")
+    print(f"{demand[t]:5.1f}", f"{value(s[t]):5.1f}", f"{value(ph[t]):5.1f}", end=" ")
     for i in unit:
         # Thermal production
-        print("%4.1f" % value(p[t][i]), end=" ")
+        print(f"{value(p[t][i]):4.1f}", end=" ")
         # The state of the unit
         if value(d[t][i]):
             print("+", end=" ")

--- a/examples/test3.py
+++ b/examples/test3.py
@@ -8,7 +8,6 @@
 # The thermal units have a proportional cost and a startup cost.
 # The hydro unit has an initial storage.
 
-from __future__ import print_function
 from pulp import *
 from math import *
 

--- a/examples/wedding.py
+++ b/examples/wedding.py
@@ -41,12 +41,12 @@ seating_model += (
 for guest in guests:
     seating_model += (
         pulp.lpSum([x[table] for table in possible_tables if guest in table]) == 1,
-        "Must_seat_%s" % guest,
+        f"Must_seat_{guest}",
     )
 
 seating_model.solve()
 
-print("The choosen tables are out of a total of %s:" % len(possible_tables))
+print(f"The choosen tables are out of a total of {len(possible_tables)}:")
 for table in possible_tables:
     if x[table].value() == 1.0:
         print(table)

--- a/examples/wedding_initial.py
+++ b/examples/wedding_initial.py
@@ -42,7 +42,7 @@ seating_model += (
 for guest in guests:
     seating_model += (
         pulp.lpSum([x[table] for table in possible_tables if guest in table]) == 1,
-        "Must_seat_%s" % guest,
+        f"Must_seat_{guest}",
     )
 
 # I've taken the optimal solution from a previous solving. x is the variable dictionary.
@@ -64,7 +64,7 @@ solver = pulp.PULP_CBC_CMD(msg=True, warmStart=True)
 seating_model.solve(solver)
 
 
-print("The choosen tables are out of a total of %s:" % len(possible_tables))
+print(f"The choosen tables are out of a total of {len(possible_tables)}:")
 for table in possible_tables:
     if x[table].value() == 1.0:
         print(table)

--- a/pulp/apis/__init__.py
+++ b/pulp/apis/__init__.py
@@ -129,7 +129,7 @@ def getSolverFromJson(filename):
     :return: a solver of type :py:class:`LpSolver`
     :rtype: LpSolver
     """
-    with open(filename, "r") as f:
+    with open(filename) as f:
         data = json.load(f)
     return getSolverFromDict(data)
 

--- a/pulp/apis/choco_api.py
+++ b/pulp/apis/choco_api.py
@@ -91,7 +91,9 @@ class CHOCO_CMD(LpSolver_CMD):
         cmd = java_path + ' -cp "' + self.path + '" org.chocosolver.parser.mps.ChocoMPS'
         if self.timeLimit is not None:
             cmd += " -tl %s" % self.timeLimit * 1000
-        cmd += " " + " ".join(["%s %s" % (key, value) for key, value in self.options])
+        cmd += " " + " ".join(
+            ["{} {}".format(key, value) for key, value in self.options]
+        )
         cmd += " %s" % tmpMps
         if lp.sense == constants.LpMaximize:
             cmd += " -max"

--- a/pulp/apis/choco_api.py
+++ b/pulp/apis/choco_api.py
@@ -90,11 +90,9 @@ class CHOCO_CMD(LpSolver_CMD):
             pass
         cmd = java_path + ' -cp "' + self.path + '" org.chocosolver.parser.mps.ChocoMPS'
         if self.timeLimit is not None:
-            cmd += " -tl %s" % self.timeLimit * 1000
-        cmd += " " + " ".join(
-            ["{} {}".format(key, value) for key, value in self.options]
-        )
-        cmd += " %s" % tmpMps
+            cmd += f" -tl {self.timeLimit}" * 1000
+        cmd += " " + " ".join([f"{key} {value}" for key, value in self.options])
+        cmd += f" {tmpMps}"
         if lp.sense == constants.LpMaximize:
             cmd += " -max"
         if lp.isMIP():

--- a/pulp/apis/coin_api.py
+++ b/pulp/apis/coin_api.py
@@ -144,7 +144,7 @@ class COIN_CMD(LpSolver_CMD):
         """Solve a MIP problem using CBC"""
         if not self.executable(self.path):
             raise PulpSolverError(
-                "Pulp: cannot execute {} cwd: {}".format(self.path, os.getcwd())
+                f"Pulp: cannot execute {self.path} cwd: {os.getcwd()}"
             )
         tmpLp, tmpMps, tmpSol, tmpMst = self.create_tmp_files(
             lp.name, "lp", "mps", "sol", "mst"
@@ -164,9 +164,9 @@ class COIN_CMD(LpSolver_CMD):
             cmds = " " + tmpLp + " "
         if self.optionsDict.get("warmStart", False):
             self.writesol(tmpMst, lp, vs, variablesNames, constraintsNames)
-            cmds += "mips {} ".format(tmpMst)
+            cmds += f"mips {tmpMst} "
         if self.timeLimit is not None:
-            cmds += "sec %s " % self.timeLimit
+            cmds += f"sec {self.timeLimit} "
         options = self.options + self.getOptions()
         for option in options:
             cmds += option + " "
@@ -476,7 +476,7 @@ class COINMP_DLL(LpSolver):
             strong=5,
             epgap=None,
             *args,
-            **kwargs
+            **kwargs,
         ):
             LpSolver.__init__(self, *args, **kwargs)
             self.fracGap = None
@@ -706,7 +706,7 @@ class YAPOSIB(LpSolver):
             timeLimit=None,
             epgap=None,
             solverName=None,
-            **solverParams
+            **solverParams,
         ):
             """
             Initializes the yaposib solver.

--- a/pulp/apis/coin_api.py
+++ b/pulp/apis/coin_api.py
@@ -144,7 +144,7 @@ class COIN_CMD(LpSolver_CMD):
         """Solve a MIP problem using CBC"""
         if not self.executable(self.path):
             raise PulpSolverError(
-                "Pulp: cannot execute %s cwd: %s" % (self.path, os.getcwd())
+                "Pulp: cannot execute {} cwd: {}".format(self.path, os.getcwd())
             )
         tmpLp, tmpMps, tmpSol, tmpMst = self.create_tmp_files(
             lp.name, "lp", "mps", "sol", "mst"
@@ -159,8 +159,8 @@ class COIN_CMD(LpSolver_CMD):
         else:
             vs = lp.writeLP(tmpLp)
             # In the Lp we do not create new variable or constraint names:
-            variablesNames = dict((v.name, v.name) for v in vs)
-            constraintsNames = dict((c, c) for c in lp.constraints)
+            variablesNames = {v.name: v.name for v in vs}
+            constraintsNames = {c: c for c in lp.constraints}
             cmds = " " + tmpLp + " "
         if self.optionsDict.get("warmStart", False):
             self.writesol(tmpMst, lp, vs, variablesNames, constraintsNames)
@@ -250,10 +250,10 @@ class COIN_CMD(LpSolver_CMD):
         """
         Read a CBC solution file generated from an mps or lp file (possible different names)
         """
-        values = dict((v.name, 0) for v in vs)
+        values = {v.name: 0 for v in vs}
 
-        reverseVn = dict((v, k) for k, v in variablesNames.items())
-        reverseCn = dict((v, k) for k, v in constraintsNames.items())
+        reverseVn = {v: k for k, v in variablesNames.items()}
+        reverseCn = {v: k for k, v in constraintsNames.items()}
 
         reducedCosts = {}
         shadowPrices = {}
@@ -283,13 +283,13 @@ class COIN_CMD(LpSolver_CMD):
         Writes a CBC solution file generated from an mps / lp file (possible different names)
         returns True on success
         """
-        values = dict((v.name, v.value() if v.value() is not None else 0) for v in vs)
+        values = {v.name: v.value() if v.value() is not None else 0 for v in vs}
         value_lines = []
         value_lines += [
             (i, v, values[k], 0) for i, (k, v) in enumerate(variablesNames.items())
         ]
         lines = ["Stopped on time - objective value 0\n"]
-        lines += ["{0:>7} {1} {2:>15} {3:>23}\n".format(*tup) for tup in value_lines]
+        lines += ["{:>7} {} {:>15} {:>23}\n".format(*tup) for tup in value_lines]
 
         with open(filename, "w") as f:
             f.writelines(lines)
@@ -301,8 +301,8 @@ class COIN_CMD(LpSolver_CMD):
         Read a CBC solution file generated from an lp (good names)
         returns status, values, reducedCosts, shadowPrices, slacks, sol_status
         """
-        variablesNames = dict((v.name, v.name) for v in vs)
-        constraintsNames = dict((c, c) for c in lp.constraints)
+        variablesNames = {v.name: v.name for v in vs}
+        constraintsNames = {c: c for c in lp.constraints}
         return self.readsol_MPS(filename, lp, vs, variablesNames, constraintsNames)
 
     def get_status(self, filename):

--- a/pulp/apis/core.py
+++ b/pulp/apis/core.py
@@ -284,9 +284,9 @@ class LpSolver:
         variables = list(lp.variables())
         numVars = len(variables)
         # associate each variable with a ordinal
-        self.v2n = dict(((variables[i], i) for i in range(numVars)))
-        self.vname2n = dict(((variables[i].name, i) for i in range(numVars)))
-        self.n2v = dict((i, variables[i]) for i in range(numVars))
+        self.v2n = {variables[i]: i for i in range(numVars)}
+        self.vname2n = {variables[i].name: i for i in range(numVars)}
+        self.n2v = {i: variables[i] for i in range(numVars)}
         # objective values
         objSense = LpObjSenses[lp.sense]
         NumVarDoubleArray = ctypes.c_double * numVars
@@ -465,7 +465,7 @@ class LpSolver_CMD(LpSolver):
             prefix = name
         else:
             prefix = os.path.join(self.tmpDir, uuid4().hex)
-        return ("%s-pulp.%s" % (prefix, n) for n in args)
+        return ("{}-pulp.{}".format(prefix, n) for n in args)
 
     def delete_tmp_files(self, *args):
         if self.keepFiles:

--- a/pulp/apis/core.py
+++ b/pulp/apis/core.py
@@ -465,7 +465,7 @@ class LpSolver_CMD(LpSolver):
             prefix = name
         else:
             prefix = os.path.join(self.tmpDir, uuid4().hex)
-        return ("{}-pulp.{}".format(prefix, n) for n in args)
+        return (f"{prefix}-pulp.{n}" for n in args)
 
     def delete_tmp_files(self, *args):
         if self.keepFiles:

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -289,7 +289,7 @@ class CPLEX_PY(LpSolver):
 
         def actualSolve(self, lp):
             """Solve a well formulated lp problem"""
-            raise PulpSolverError("CPLEX_PY: Not Available:\n{}".format(self.err))
+            raise PulpSolverError(f"CPLEX_PY: Not Available:\n{self.err}")
 
     else:
 

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -367,7 +367,7 @@ class CPLEX_PY(LpSolver):
             Takes the pulp lp model and translates it into a cplex model
             """
             model_variables = lp.variables()
-            self.n2v = dict((var.name, var) for var in model_variables)
+            self.n2v = {var.name: var for var in model_variables}
             if len(self.n2v) != len(model_variables):
                 raise PulpSolverError(
                     "Variables must have unique names for cplex solver"

--- a/pulp/apis/gurobi_api.py
+++ b/pulp/apis/gurobi_api.py
@@ -73,7 +73,7 @@ class GUROBI(LpSolver):
             gapRel=None,
             warmStart=False,
             logPath=None,
-            **solverParams
+            **solverParams,
         ):
             """
             :param bool mip: if False, assume LP even if integer variables
@@ -167,7 +167,7 @@ class GUROBI(LpSolver):
             try:
                 gurobipy.setParam("_test", 0)
             except gurobipy.GurobiError as e:
-                warnings.warn("GUROBI error: {}.".format(e))
+                warnings.warn(f"GUROBI error: {e}.")
                 return False
             return True
 
@@ -354,7 +354,7 @@ class GUROBI_CMD(LpSolver_CMD):
             # normal execution
             return True
         # error: we display the gurobi message
-        warnings.warn("GUROBI error: {}.".format(out))
+        warnings.warn(f"GUROBI error: {out}.")
         return False
 
     def actualSolve(self, lp):
@@ -372,16 +372,16 @@ class GUROBI_CMD(LpSolver_CMD):
         options = self.options + self.getOptions()
         if self.timeLimit is not None:
             options.append(("TimeLimit", self.timeLimit))
-        cmd += " " + " ".join(["{}={}".format(key, value) for key, value in options])
-        cmd += " ResultFile=%s" % tmpSol
+        cmd += " " + " ".join([f"{key}={value}" for key, value in options])
+        cmd += f" ResultFile={tmpSol}"
         if self.optionsDict.get("warmStart", False):
             self.writesol(filename=tmpMst, vs=vs)
-            cmd += " InputFile=%s" % tmpMst
+            cmd += f" InputFile={tmpMst}"
 
         if lp.isMIP():
             if not self.mip:
                 warnings.warn("GUROBI_CMD does not allow a problem to be relaxed")
-        cmd += " %s" % tmpLp
+        cmd += f" {tmpLp}"
         if self.msg:
             pipe = None
         else:
@@ -442,7 +442,7 @@ class GUROBI_CMD(LpSolver_CMD):
         values = [(v.name, v.value()) for v in vs if v.value() is not None]
         rows = []
         for name, value in values:
-            rows.append("{} {}".format(name, value))
+            rows.append(f"{name} {value}")
         with open(filename, "w") as f:
             f.write("\n".join(rows))
         return True

--- a/pulp/apis/gurobi_api.py
+++ b/pulp/apis/gurobi_api.py
@@ -372,7 +372,7 @@ class GUROBI_CMD(LpSolver_CMD):
         options = self.options + self.getOptions()
         if self.timeLimit is not None:
             options.append(("TimeLimit", self.timeLimit))
-        cmd += " " + " ".join(["%s=%s" % (key, value) for key, value in options])
+        cmd += " " + " ".join(["{}={}".format(key, value) for key, value in options])
         cmd += " ResultFile=%s" % tmpSol
         if self.optionsDict.get("warmStart", False):
             self.writesol(filename=tmpMst, vs=vs)

--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -137,7 +137,7 @@ class HiGHS_CMD(LpSolver_CMD):
         # The return code for HiGHS on command line follows: 0:program ran successfully, 1: warning, -1: error - https://github.com/ERGO-Code/HiGHS/issues/527#issuecomment-946575028
         return_code = proc.wait()
         if return_code in [0, 1]:
-            with open(tmpLog, "r") as log_file:
+            with open(tmpLog) as log_file:
                 content = log_file.readlines()
             content = [l.strip().split() for l in content]
             # LP

--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -81,7 +81,7 @@ class HiGHS_CMD(LpSolver_CMD):
             lp.name, "mps", "sol", "HiGHS", "HiGHS_log"
         )
         write_lines = [
-            "solution_file = %s\n" % tmpSol,
+            f"solution_file = {tmpSol}\n",
             "write_solution_to_file = true\n",
         ]
         with open(tmpOptions, "w") as fp:
@@ -104,10 +104,10 @@ class HiGHS_CMD(LpSolver_CMD):
         except:
             pass
         cmd = self.path
-        cmd += " %s" % tmpMps
-        cmd += " --options_file %s" % tmpOptions
+        cmd += f" {tmpMps}"
+        cmd += f" --options_file {tmpOptions}"
         if self.timeLimit is not None:
-            cmd += " --time_limit %s" % self.timeLimit
+            cmd += f" --time_limit {self.timeLimit}"
         for option in self.options:
             cmd += " " + option
         if lp.isMIP():

--- a/pulp/apis/mipcl_api.py
+++ b/pulp/apis/mipcl_api.py
@@ -92,10 +92,10 @@ class MIPCL_CMD(LpSolver_CMD):
         except:
             pass
         cmd = self.path
-        cmd += " %s" % tmpMps
-        cmd += " -solfile %s" % tmpSol
+        cmd += f" {tmpMps}"
+        cmd += f" -solfile {tmpSol}"
         if self.timeLimit is not None:
-            cmd += " -time %s" % self.timeLimit
+            cmd += f" -time {self.timeLimit}"
         for option in self.options:
             cmd += " " + option
         if lp.isMIP():

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -112,9 +112,9 @@ class SCIP_CMD(LpSolver_CMD):
         tmpLp, tmpSol = self.create_tmp_files(lp.name, "lp", "sol")
         lp.writeLP(tmpLp)
 
-        proc = ["%s" % self.path, "-c", 'read "%s"' % tmpLp]
+        proc = [f"{self.path}", "-c", f'read "{tmpLp}"']
         if self.timeLimit is not None:
-            proc.extend(["-c", "set limits time {}".format(self.timeLimit)])
+            proc.extend(["-c", f"set limits time {self.timeLimit}"])
 
         options = self.options + self.getOptions()
         options = list(itertools.chain(*[("-c", o) for o in options]))
@@ -124,7 +124,7 @@ class SCIP_CMD(LpSolver_CMD):
         if not self.msg:
             proc.append("-q")
         proc.extend(
-            ["-c", "optimize", "-c", 'write solution "%s"' % tmpSol, "-c", "quit"]
+            ["-c", "optimize", "-c", f'write solution "{tmpSol}"', "-c", "quit"]
         )
 
         stdout = self.firstWithFilenoSupport(sys.stdout, sys.__stdout__)
@@ -174,7 +174,7 @@ class SCIP_CMD(LpSolver_CMD):
                 assert comps[0] == "solution status"
                 assert len(comps) == 2
             except Exception:
-                raise PulpSolverError("Can't get SCIP solver status: %r" % line)
+                raise PulpSolverError(f"Can't get SCIP solver status: {line!r}")
 
             status = SCIP_CMD.SCIP_STATUSES.get(
                 comps[1].strip(), constants.LpStatusUndefined
@@ -192,7 +192,7 @@ class SCIP_CMD(LpSolver_CMD):
                 assert len(comps) == 2
                 float(comps[1].strip())
             except Exception:
-                raise PulpSolverError("Can't get SCIP solver objective: %r" % line)
+                raise PulpSolverError(f"Can't get SCIP solver objective: {line!r}")
 
             # Parse the variable values.
             for line in f:
@@ -200,7 +200,7 @@ class SCIP_CMD(LpSolver_CMD):
                     comps = line.split()
                     values[comps[0]] = float(comps[1])
                 except:
-                    raise PulpSolverError("Can't read SCIP solver output: %r" % line)
+                    raise PulpSolverError(f"Can't read SCIP solver output: {line!r}")
 
             return status, values
 

--- a/pulp/apis/xpress_api.py
+++ b/pulp/apis/xpress_api.py
@@ -167,7 +167,7 @@ class XPRESS(LpSolver_CMD):
                 cmd.write("MAXTIME=%d\n" % self.timeLimit)
             targetGap = self.optionsDict.get("gapRel")
             if targetGap is not None:
-                cmd.write("MIPRELSTOP=%f\n" % targetGap)
+                cmd.write(f"MIPRELSTOP={targetGap:f}\n")
             heurFreq = self.optionsDict.get("heurFreq")
             if heurFreq is not None:
                 cmd.write("HEURFREQ=%d\n" % heurFreq)
@@ -191,11 +191,11 @@ class XPRESS(LpSolver_CMD):
             # The writeprtsol command must be in lower case for correct filename handling
             cmd.write("writeprtsol " + self.quote_path(tmpSol) + "\n")
             cmd.write(
-                "set fh [open %s w]; list\n" % self.quote_path(tmpAttr)
+                f"set fh [open {self.quote_path(tmpAttr)} w]; list\n"
             )  # `list` to suppress output
 
             for attr in attrNames:
-                cmd.write('puts $fh "{}=${}"\n'.format(attr, attr))
+                cmd.write(f'puts $fh "{attr}=${attr}"\n')
             cmd.write("close $fh\n")
             cmd.write("QUIT\n")
         with open(tmpCmd) as cmd:
@@ -314,7 +314,7 @@ class XPRESS(LpSolver_CMD):
             for i, sol in enumerate(values):
                 slx.write("NAME solution%d\n" % i)
                 for name, value in sol:
-                    slx.write(" C      {} {:.16f}\n".format(name, value))
+                    slx.write(f" C      {name} {value:.16f}\n")
             slx.write("ENDATA\n")
 
     @staticmethod

--- a/pulp/apis/xpress_api.py
+++ b/pulp/apis/xpress_api.py
@@ -195,10 +195,10 @@ class XPRESS(LpSolver_CMD):
             )  # `list` to suppress output
 
             for attr in attrNames:
-                cmd.write('puts $fh "%s=$%s"\n' % (attr, attr))
+                cmd.write('puts $fh "{}=${}"\n'.format(attr, attr))
             cmd.write("close $fh\n")
             cmd.write("QUIT\n")
-        with open(tmpCmd, "r") as cmd:
+        with open(tmpCmd) as cmd:
             consume = False
             subout = None
             suberr = None
@@ -314,12 +314,12 @@ class XPRESS(LpSolver_CMD):
             for i, sol in enumerate(values):
                 slx.write("NAME solution%d\n" % i)
                 for name, value in sol:
-                    slx.write(" C      %s %.16f\n" % (name, value))
+                    slx.write(" C      {} {:.16f}\n".format(name, value))
             slx.write("ENDATA\n")
 
     @staticmethod
     def quote_path(path):
-        """
+        r"""
         Quotes a path for the Xpress optimizer console, by wrapping it in
         double quotes and escaping the following characters, which would
         otherwise be interpreted by the Tcl shell: \ $ " [

--- a/pulp/mps_lp.py
+++ b/pulp/mps_lp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 
 @author: Franco Peschiera
@@ -52,7 +51,7 @@ def readMPS(path, sense, dropConsNames=False):
     bnd_names = []
     integral_marker = False
 
-    with open(path, "r") as reader:
+    with open(path) as reader:
         for line in reader:
             line = re.split(" |\t", line)
             line = [x.strip() for x in line]
@@ -206,8 +205,8 @@ def writeMPS(LpProblem, filename, mpsSense=0, rename=0, mip=1):
         vs = LpProblem._variables
     else:
         vs = LpProblem.variables()
-        varNames = dict((v.name, v.name) for v in vs)
-        constrNames = dict((c, c) for c in LpProblem.constraints)
+        varNames = {v.name: v.name for v in vs}
+        constrNames = {c: c for c in LpProblem.constraints}
     model_name = LpProblem.name
     if rename:
         model_name = "MODEL"
@@ -384,12 +383,12 @@ def writeLP(LpProblem, filename, writeSOS=1, mip=1, max_length=100):
             for sos in LpProblem.sos1.values():
                 f.write("S1:: \n")
                 for v, val in sos.items():
-                    f.write(" %s: %.12g\n" % (v.name, val))
+                    f.write(" {}: {:.12g}\n".format(v.name, val))
         if LpProblem.sos2:
             for sos in LpProblem.sos2.values():
                 f.write("S2:: \n")
                 for v, val in sos.items():
-                    f.write(" %s: %.12g\n" % (v.name, val))
+                    f.write(" {}: {:.12g}\n".format(v.name, val))
     f.write("End\n")
     f.close()
     LpProblem.restoreObjective(wasNone, objectiveDummyVar)

--- a/pulp/mps_lp.py
+++ b/pulp/mps_lp.py
@@ -95,7 +95,7 @@ def readMPS(path, sense, dropConsNames=False):
                         sense=ROW_EQUIV[row_type],
                         name=row_name,
                         coefficients=[],
-                        **ROW_DEFAULT
+                        **ROW_DEFAULT,
                     )
             elif mode == CORE_FILE_COL_MODE:
                 var_name = line[0]
@@ -250,7 +250,7 @@ def writeMPS(LpProblem, filename, mpsSense=0, rename=0, mip=1):
         f.write("*SENSE:" + const.LpSenses[mpsSense] + "\n")
         f.write("NAME          " + model_name + "\n")
         f.write("ROWS\n")
-        f.write(" N  %s\n" % objName)
+        f.write(f" N  {objName}\n")
         f.write("".join(row_lines))
         f.write("COLUMNS\n")
         f.write("".join(columns_lines))
@@ -362,20 +362,20 @@ def writeLP(LpProblem, filename, writeSOS=1, mip=1, max_length=100):
     if vg:
         f.write("Bounds\n")
         for v in vg:
-            f.write(" %s\n" % v.asCplexLpVariable())
+            f.write(f" {v.asCplexLpVariable()}\n")
     # Integer non-binary variables
     if mip:
         vg = [v for v in vs if v.cat == const.LpInteger and not v.isBinary()]
         if vg:
             f.write("Generals\n")
             for v in vg:
-                f.write("%s\n" % v.name)
+                f.write(f"{v.name}\n")
         # Binary variables
         vg = [v for v in vs if v.isBinary()]
         if vg:
             f.write("Binaries\n")
             for v in vg:
-                f.write("%s\n" % v.name)
+                f.write(f"{v.name}\n")
     # Special Ordered Sets
     if writeSOS and (LpProblem.sos1 or LpProblem.sos2):
         f.write("SOS\n")
@@ -383,12 +383,12 @@ def writeLP(LpProblem, filename, writeSOS=1, mip=1, max_length=100):
             for sos in LpProblem.sos1.values():
                 f.write("S1:: \n")
                 for v, val in sos.items():
-                    f.write(" {}: {:.12g}\n".format(v.name, val))
+                    f.write(f" {v.name}: {val:.12g}\n")
         if LpProblem.sos2:
             for sos in LpProblem.sos2.values():
                 f.write("S2:: \n")
                 for v, val in sos.items():
-                    f.write(" {}: {:.12g}\n".format(v.name, val))
+                    f.write(f" {v.name}: {val:.12g}\n")
     f.write("End\n")
     f.close()
     LpProblem.restoreObjective(wasNone, objectiveDummyVar)

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -106,7 +106,7 @@ try:
     from collections.abc import Iterable
 except ImportError:
     # python 2.7 compatible
-    from collections import Iterable
+    from collections.abc import Iterable
 
 import logging
 
@@ -143,7 +143,7 @@ except ImportError:
 import re
 
 
-class LpElement(object):
+class LpElement:
     """Base class for LpVariable and LpConstraintVar"""
 
     # To remove illegal characters from the names
@@ -715,19 +715,19 @@ class LpAffineExpression(_DICT_TYPE):
         if isinstance(e, LpAffineExpression):
             # Will not copy the name
             self.constant = e.constant
-            super(LpAffineExpression, self).__init__(list(e.items()))
+            super().__init__(list(e.items()))
         elif isinstance(e, dict):
             self.constant = constant
-            super(LpAffineExpression, self).__init__(list(e.items()))
+            super().__init__(list(e.items()))
         elif isinstance(e, Iterable):
             self.constant = constant
-            super(LpAffineExpression, self).__init__(e)
+            super().__init__(e)
         elif isinstance(e, LpElement):
             self.constant = 0
-            super(LpAffineExpression, self).__init__([(e, 1)])
+            super().__init__([(e, 1)])
         else:
             self.constant = e
-            super(LpAffineExpression, self).__init__()
+            super().__init__()
 
     # Proxy functions for variables
 
@@ -842,10 +842,10 @@ class LpAffineExpression(_DICT_TYPE):
                 sign = ""
             notFirst = 1
             if val == 1:
-                term = "%s %s" % (sign, v.name)
+                term = "{} {}".format(sign, v.name)
             else:
                 # adding zero to val to remove instances of negative zero
-                term = "%s %.12g %s" % (sign, val + 0, v.name)
+                term = "{} {:.12g} {}".format(sign, val + 0, v.name)
 
             if self._count_characters(line) + len(term) > const.LpCplexLPLineSize:
                 result += ["".join(line)]
@@ -1086,7 +1086,7 @@ class LpConstraint(LpAffineExpression):
         c = -self.constant
         if c == 0:
             c = 0  # Supress sign
-        term = " %s %.12g" % (const.LpConstraintSenses[self.sense], c)
+        term = " {} {:.12g}".format(const.LpConstraintSenses[self.sense], c)
         if self._count_characters(line) + len(term) > const.LpCplexLPLineSize:
             result += ["".join(line)]
             line = [term]
@@ -1333,7 +1333,7 @@ class LpConstraintVar(LpElement):
         return self.constraint.value()
 
 
-class LpProblem(object):
+class LpProblem:
     """An LP Problem"""
 
     def __init__(self, name="NoName", sense=const.LpMinimize):
@@ -1530,7 +1530,7 @@ class LpProblem(object):
         :return: a tuple with a dictionary of variables and an LpProblem
         :rtype: (dict, :py:class:`LpProblem`)
         """
-        with open(filename, "r") as f:
+        with open(filename) as f:
             data = json.load(f)
         return cls.fromDict(data)
 
@@ -2106,7 +2106,9 @@ class FixedElasticSubProblem(LpProblem):
                 % (self.name, upVar, lowVar, freeVar, result)
             )
             log.debug(
-                "isViolated value lhs %s constant %s" % (self.findLHSValue(), self.RHS)
+                "isViolated value lhs {} constant {}".format(
+                    self.findLHSValue(), self.RHS
+                )
             )
         return result
 

--- a/pulp/sparse.py
+++ b/pulp/sparse.py
@@ -37,8 +37,8 @@ class Matrix(dict):
         """
         self.rows = rows
         self.cols = cols
-        self.rowdict = dict([(row, {}) for row in rows])
-        self.coldict = dict([(col, {}) for col in cols])
+        self.rowdict = {row: {} for row in rows}
+        self.coldict = {col: {} for col in cols}
 
     def add(self, row, col, item, colcheck=False, rowcheck=False):
         if not (rowcheck and row not in self.rows):

--- a/pulp/sparse.py
+++ b/pulp/sparse.py
@@ -48,9 +48,9 @@ class Matrix(dict):
                 self.coldict[col][row] = item
             else:
                 print(self.cols)
-                raise RuntimeError("col %s is not in the matrix columns" % col)
+                raise RuntimeError(f"col {col} is not in the matrix columns")
         else:
-            raise RuntimeError("row %s is not in the matrix rows" % row)
+            raise RuntimeError(f"row {row} is not in the matrix rows")
 
     def addcol(self, col, rowitems):
         """adds a column"""

--- a/pulp/tests/bin_packing_problem.py
+++ b/pulp/tests/bin_packing_problem.py
@@ -38,9 +38,7 @@ def create_bin_packing_problem(bins, seed=0):
 
     # pack every item
     for i in item_indices:
-        prob += lpSum(
-            items_packed[i, b] for b in bin_indices
-        ) == 1, "pack_item_{}".format(i)
+        prob += lpSum(items_packed[i, b] for b in bin_indices) == 1, f"pack_item_{i}"
 
     # no bin overfilled
     for b in bin_indices:
@@ -48,6 +46,6 @@ def create_bin_packing_problem(bins, seed=0):
             lpSum([items[i] * items_packed[i, b] for i in item_indices])
             <= bin_size * using_bin[b]
         )
-        prob += expr, "respect_bin_size_{}".format(b)
+        prob += expr, f"respect_bin_size_{b}"
 
     return prob

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -813,7 +813,7 @@ class BaseSolverTest:
             prob += w >= 0, "c4"
             data = prob.toDict()
             var1, prob1 = LpProblem.fromDict(data)
-            x, y, z, w = [var1[name] for name in ["x", "y", "z", "w"]]
+            x, y, z, w = (var1[name] for name in ["x", "y", "z", "w"])
             print("\t Testing continuous LP solution - export dict")
             pulpTestCheck(
                 prob1, self.solver, [const.LpStatusOptimal], {x: 4, y: -1, z: 6, w: 0}
@@ -831,7 +831,7 @@ class BaseSolverTest:
             prob += w >= 0, "c4"
             data = prob.toDict()
             var1, prob1 = LpProblem.fromDict(data)
-            x, y, z, w = [var1[name] for name in ["x", "y", "z", "w"]]
+            x, y, z, w = (var1[name] for name in ["x", "y", "z", "w"])
             print("\t Testing export dict for LP")
             pulpTestCheck(
                 prob1, self.solver, [const.LpStatusOptimal], {x: 4, y: 1, z: 6, w: 0}
@@ -856,7 +856,7 @@ class BaseSolverTest:
                 os.remove(filename)
             except:
                 pass
-            x, y, z, w = [var1[name] for name in ["x", "y", "z", "w"]]
+            x, y, z, w = (var1[name] for name in ["x", "y", "z", "w"])
             print("\t Testing continuous LP solution - export JSON")
             pulpTestCheck(
                 prob1, self.solver, [const.LpStatusOptimal], {x: 4, y: -1, z: 6, w: 0}
@@ -876,7 +876,7 @@ class BaseSolverTest:
             data = prob.toDict()
             data_backup = copy.deepcopy(data)
             var1, prob1 = LpProblem.fromDict(data)
-            x, y, z = [var1[name] for name in ["x", "y", "z"]]
+            x, y, z = (var1[name] for name in ["x", "y", "z"])
             print("\t Testing export dict MIP")
             pulpTestCheck(
                 prob1, self.solver, [const.LpStatusOptimal], {x: 3, y: -0.5, z: 7}
@@ -897,7 +897,7 @@ class BaseSolverTest:
             prob += w >= 0, "c4"
             data = prob.toDict()
             var1, prob1 = LpProblem.fromDict(data)
-            x, y, z, w = [var1[name] for name in ["x", "y", "z", "w"]]
+            x, y, z, w = (var1[name] for name in ["x", "y", "z", "w"])
             print("\t Testing maximize continuous LP solution")
             pulpTestCheck(
                 prob1, self.solver, [const.LpStatusOptimal], {x: 4, y: 1, z: 8, w: 0}

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -52,11 +52,11 @@ class BaseSolverTest:
         def setUp(self):
             self.solver = self.solveInst(msg=False)
             if not self.solver.available():
-                self.skipTest("solver {} not available".format(self.solveInst))
+                self.skipTest(f"solver {self.solveInst} not available")
 
         def tearDown(self):
             for ext in ["mst", "log", "lp", "mps", "sol"]:
-                filename = "{}.{}".format(self._testMethodName, ext)
+                filename = f"{self._testMethodName}.{ext}"
                 try:
                     os.remove(filename)
                 except:
@@ -1021,9 +1021,9 @@ class BaseSolverTest:
                     {x: 4, y: -1, z: 6, w: 0},
                 )
                 if not os.path.exists(logFilename):
-                    raise PulpError("Test failed for solver: {}".format(self.solver))
+                    raise PulpError(f"Test failed for solver: {self.solver}")
                 if not os.path.getsize(logFilename):
-                    raise PulpError("Test failed for solver: {}".format(self.solver))
+                    raise PulpError(f"Test failed for solver: {self.solver}")
 
         def test_makeDict_behavior(self):
             """
@@ -1230,7 +1230,7 @@ class BaseSolverTest:
                 reported_time,
                 time_limit,
                 delta=delta,
-                msg="optimization time for solver {}".format(self.solver.name),
+                msg=f"optimization time for solver {self.solver.name}",
             )
 
         def test_invalid_var_names(self):
@@ -1487,7 +1487,7 @@ def pulpTestCheck(
     eps=10**-3,
     status=None,
     objective=None,
-    **kwargs
+    **kwargs,
 ):
     if status is None:
         status = prob.solve(solver, **kwargs)
@@ -1545,9 +1545,7 @@ def pulpTestCheck(
         if abs(z - objective) > eps:
             dumpTestProblem(prob)
             raise PulpError(
-                "Tests failed for solver {}:\nobjective {} != {}".format(
-                    solver, z, objective
-                )
+                f"Tests failed for solver {solver}:\nobjective {z} != {objective}"
             )
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "Programming Language :: Python",
         "Topic :: Scientific/Engineering :: Mathematics",
     ],
+    python_requires=">=3.7",
     # need the cbc directories here as the executable bit is set
     packages=[
         "pulp",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ version_dict = {}
 exec(open("pulp/constants.py").read(), version_dict)
 VERSION = version_dict["VERSION"]
 
-with open(readme_name, "r") as fh:
+with open(readme_name) as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
This PR upgrades the code base to Python 3.7, including:
 - Requiring Python 3.7 in setup.py
 - Upgrades to Python 3.7+ syntax using Pyupgrade and flynt
 - Updating the Readme
 - Updating the packaging CI
See each individual commit for details.

Python 3.6 support has been dropped almost a year ago and Python 2.7 is end-of-life for almost 3 years now.

These changes affect only future releases, older releases like 2.6.0 can still be used with the old Python versions.

Closes #552.