### PR TITLE
CI: Update docs and publish workflows

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -5,19 +5,15 @@ on:
     branches:
       - master
 
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         # Semantic version range syntax or exact version of a Python version
-        python-version: '3.8'
-        architecture: 'x64'
+        python-version: '3.10'
     # Standard drop-in approach that should work for most people.
     - name: Install dependencies
       run: |

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -5,13 +5,13 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: "3.10"
     - name: Install wheel
       run: >-
         python -m
@@ -22,13 +22,12 @@ jobs:
       run: python setup.py sdist bdist_wheel
     - name: Publish distribution 📦 to Test PyPI
       if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.pypi_password }}
-


### PR DESCRIPTION
A bit of maintenance on the docs and publish GitHub Actions workflows.

Both are updated to the latest versions of checkout and setup-python, as wel as a recent Python version and the latest Ubuntu image.

Using the master branch of pypa/gh-action-pypi-publish is [deprecated](https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-), so the release/v1 branch is now used.