### PR TITLE
Add more config parameters to HiGHS python API + set up logging

### DIFF
--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -300,20 +300,20 @@ class HiGHS(LpSolver):
                 )
                 lp.solverModel.setLogCallback(*callbackTuple)
 
-            options = {
-                **({} if self.gapRel is None else {"mip_rel_gap": self.gapRel}),
-                **({} if self.gapAbs is None else {"mip_abs_gap": self.gapAbs}),
-                **({} if self.threads is None else {"threads": self.threads}),
-                **(
-                    {}
-                    if self.timeLimit is None
-                    else {"time_limit": float(self.timeLimit)}
-                ),
-                **self.optionsDict,
-            }
+            if self.gapRel is not None:
+                lp.solverModel.setOptionValue("mip_rel_gap", self.gapRel)
 
-            for name, val in options.items():
-                lp.solverModel.setOptionValue(name, val)
+            if self.gapAbs is not None:
+                lp.solverModel.setOptionValue("mip_abs_gap", self.gapAbs)
+
+            if self.threads is not None:
+                lp.solverModel.setOptionValue("threads", self.threads)
+
+            if self.timeLimit is not None:
+                lp.solverModel.setOptionValue("time_limit", float(self.timeLimit))
+
+            for key, value in self.optionsDict.items():
+                lp.solverModel.setOptionValue(key, value)
 
         def buildSolverModel(self, lp):
             inf = highspy.kHighsInf

--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -276,7 +276,7 @@ class HiGHS(LpSolver):
             :param float gapAbs: absolute gap tolerance for the solver to stop
             :param int threads: sets the maximum number of threads
             :param float timeLimit: maximum time for solver (in seconds)
-            :param dict solverParams list of named options to pass to the HiGHS solver
+            :param dict solverParams: list of named options to pass directly to the HiGHS solver
             """
             super().__init__(mip=mip, msg=msg, timeLimit=timeLimit, **solverParams)
             self.callbackTuple = callbackTuple
@@ -312,6 +312,7 @@ class HiGHS(LpSolver):
             if self.timeLimit is not None:
                 lp.solverModel.setOptionValue("time_limit", float(self.timeLimit))
 
+            # set remaining parameter values
             for key, value in self.optionsDict.items():
                 lp.solverModel.setOptionValue(key, value)
 

--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -248,17 +248,41 @@ class HiGHS(LpSolver):
             raise PulpSolverError("HiGHS: Not Available")
 
     else:
+        # Note(maciej): It was surprising to me that higshpy wasn't logging out of the box,
+        #  even with the different logging options set. This callback seems to work, but there
+        #  are probably better ways of doing this ¯\_(ツ)_/¯
+        DEFAULT_CALLBACK = lambda logType, logMsg, callbackValue: print(
+            f"[{logType.name}] {logMsg}"
+        )
+        DEFAULT_CALLBACK_VALUE = ""
 
         def __init__(
             self,
             mip=True,
             msg=True,
+            callbackTuple=None,
+            gapAbs=None,
+            gapRel=None,
+            threads=None,
             timeLimit=None,
-            warmStart=False,
-            logPath=None,
             **solverParams,
         ):
-            super().__init__(mip, msg, timeLimit=timeLimit, **solverParams)
+            """
+            :param bool mip: if False, assume LP even if integer variables
+            :param bool msg: if False, no log is shown
+            :param tuple callbackTuple: Tuple of log callback function (see DEFAULT_CALLBACK above for definition)
+                and callbackValue (tag embedded in every callback)
+            :param float gapRel: relative gap tolerance for the solver to stop (in fraction)
+            :param float gapAbs: absolute gap tolerance for the solver to stop
+            :param int threads: sets the maximum number of threads
+            :param float timeLimit: maximum time for solver (in seconds)
+            :param dict solverParams list of named options to pass to the HiGHS solver
+            """
+            super().__init__(mip=mip, msg=msg, timeLimit=timeLimit, **solverParams)
+            self.callbackTuple = callbackTuple
+            self.gapAbs = gapAbs
+            self.gapRel = gapRel
+            self.threads = threads
 
         def available(self):
             return True
@@ -266,19 +290,32 @@ class HiGHS(LpSolver):
         def callSolver(self, lp):
             lp.solverModel.run()
 
-        def buildSolverModel(self, lp):
+        def createAndConfigureSolver(self, lp):
             lp.solverModel = highspy.Highs()
 
-            gapRel = self.optionsDict.get("gapRel", 0)
-            lp.solverModel.setOptionValue("mip_rel_gap", gapRel)
+            if self.msg or self.callbackTuple:
+                callbackTuple = self.callbackTuple or (
+                    HiGHS.DEFAULT_CALLBACK,
+                    HiGHS.DEFAULT_CALLBACK_VALUE,
+                )
+                lp.solverModel.setLogCallback(*callbackTuple)
 
-            if self.timeLimit is not None:
-                lp.solverModel.setOptionValue("time_limit", float(self.timeLimit))
+            options = {
+                **({} if self.gapRel is None else {"mip_rel_gap": self.gapRel}),
+                **({} if self.gapAbs is None else {"mip_abs_gap": self.gapAbs}),
+                **({} if self.threads is None else {"threads": self.threads}),
+                **(
+                    {}
+                    if self.timeLimit is None
+                    else {"time_limit": float(self.timeLimit)}
+                ),
+                **self.optionsDict,
+            }
 
-            # set remaining parameter values
-            for key, value in self.optionsDict.items():
-                lp.solverModel.setOptionValue(key, value)
+            for name, val in options.items():
+                lp.solverModel.setOptionValue(name, val)
 
+        def buildSolverModel(self, lp):
             inf = highspy.kHighsInf
 
             obj_mult = -1 if lp.sense == constants.LpMaximize else 1
@@ -353,6 +390,7 @@ class HiGHS(LpSolver):
             return status_dict[status]
 
         def actualSolve(self, lp):
+            self.createAndConfigureSolver(lp)
             self.buildSolverModel(lp)
             self.callSolver(lp)
 


### PR DESCRIPTION
### Reference issue

https://github.com/coin-or/pulp/issues/553  (sort of )

### What does this implement?

Improves the usability of the HiGHS interface:
* Pass more of pulp's parameters directly into HiGHS
* Set-up logging (it's a bit awkward, I wasn't sure if there's a better way to do this)
* Allow callers to specify more options via the options argument

### Any other comments

N/A
