### PR TITLE
Readme: Add badges with latest PyPI release and monthly downloads

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,14 @@
 pulp
 **************************
+
 .. image:: https://travis-ci.org/coin-or/pulp.svg?branch=master
     :target: https://travis-ci.org/coin-or/pulp
+.. image:: https://img.shields.io/pypi/v/pulp
+    :target: https://pypi.org/project/PuLP/
+    :alt: PyPI
+.. image:: https://img.shields.io/pypi/dm/pulp
+    :target: https://pypi.org/project/PuLP/
+    :alt: PyPI - Downloads
 
 PuLP is an LP modeler written in Python. PuLP can generate MPS or LP files and call GLPK_, COIN-OR CLP/`CBC`_, CPLEX_, GUROBI_, MOSEK_, XPRESS_, CHOCO_, MIPCL_, HiGHS_, SCIP_/FSCIP_ to solve linear problems.
 


### PR DESCRIPTION
Add two PyPI badges to the readme, one with the latest version and one with the number of monthly downloads. This increases visibility and makes the PuLP easier to find on PyPI (since both link to https://pypi.org/project/PuLP/).