### PR TITLE
publish CI maintenance: Update Python, use build, run on PRs

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,33 +1,28 @@
 name: Publish Python 🐍 distributions 📦 to PyPI
 
-on: push
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python 3.10
+    - uses: actions/checkout@v3
+    - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
-    - name: Install wheel
-      run: >-
-        python -m
-        pip install
-        wheel
-        --user
+        python-version: "3.x"
+    - run: pip install -U wheel build
     - name: Build a binary wheel and a source tarball
-      run: python setup.py sdist bdist_wheel
+      run: python -m build
     - name: Publish distribution 📦 to Test PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
A bit of maintenance on the publish CI workflow:
 - Run also on Pull Requests and when [manually triggered](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) (`workflow_dispatch`)
 - Use the latest stable checkout version (v3)
 - Use the latest stable Python version (3.x)
 - Switch to [Build](https://pypi.org/project/build/) for distribution building, since calling `setup.py` directly is deprecated (see [Why you shouldn't invoke setup.py directly](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html))
- Only publish when the workflow is triggered by a push and the commit is a tag