### PR TITLE
Fix TypeError in LpElement.__bool__

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -192,7 +192,7 @@ class LpElement:
         return self
 
     def __bool__(self):
-        return 1
+        return True
 
     def __add__(self, other):
         return LpAffineExpression(self) + other


### PR DESCRIPTION
A TypeError is raised when assessing an LpVariable in conditions. The issue is present  in Python3.8 - 3.11.

One example where this issue came around is when the decision variable structure (e.g. a matrix) is fixed, 
but it is not complete and some variables must be omitted based on the current problem using `None`.

Example use case:
```python
Python 3.10.9 (main, Dec  7 2022, 01:12:00) [GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
>>> import pulp
>>> prob = pulp.LpProblem('Test')
>>> X = [pulp.LpVariable('x_1'), None, pulp.LpVariable('x_3')]
>>> prob += pulp.lpSum(X) <= 6
>>> prob
Test:
MINIMIZE
None
SUBJECT TO
_C1: x_1 + x_3 <= 6

VARIABLES
x_1 free Continuous
x_3 free Continuous

>>> print([pulp.value(x) for x in X if x])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 1, in <listcomp>
TypeError: __bool__ should return bool, returned int
>>> 
```