### PR TITLE
Add boolean assessment of LpVariable based on LpVariable.varValue

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -192,7 +192,7 @@ class LpElement:
         return self
 
     def __bool__(self):
-        return 1
+        return True
 
     def __add__(self, other):
         return LpAffineExpression(self) + other
@@ -613,7 +613,7 @@ class LpVariable(LpElement):
             return 1
 
     def __bool__(self):
-        return bool(self.varValue)
+        return bool(self.roundedValue())
 
     def addVariableToConstraints(self, e):
         """adds a variable to the constraints indicated by

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -612,6 +612,9 @@ class LpVariable(LpElement):
         else:
             return 1
 
+    def __bool__(self):
+        return bool(self.varValue)
+
     def addVariableToConstraints(self, e):
         """adds a variable to the constraints indicated by
         the LpConstraintVars in e


### PR DESCRIPTION
After solving an ILP problem, assessing the result requires checking the values of decision variables one-by-one.
A straightforward, convenient and pythonic way would be to be able to assess the result by considering the calculated
values of these variables implicitly, that is based on the `varValue` attributes.

It would be extremely convenient with `LpBinary` type of variables where interested variables store `1` and others `0`.
In the specific case where the problem has not solved yet (`LpVariable.varValue = None`) or the structure of variables 
contains omitted variables or placeholders in the form of `None` (see example in #616), boolean assessment would 
work seamlessly.

Example use case:
```python
$ python3.10 -i pulp/examples/test2.py

...

Result - Optimal solution found

Objective value:                4190215.00000000
Enumerated nodes:               0
Total iterations:               9
Time (CPU seconds):             0.02
Time (Wallclock seconds):       0.03

Option for printingOptions changed from normal to all
Total time (CPU seconds):       0.02   (Wallclock seconds):       0.03

Status: Optimal
x_0 = 1.0
x_1 = 1.0
x_10 = 0.0
x_11 = 0.0
x_12 = 0.0
x_13 = 0.0
x_14 = 0.0
x_2 = 1.0
x_3 = 1.0
x_4 = 1.0
x_5 = 1.0
x_6 = 1.0
x_7 = 0.0
x_8 = 0.0
x_9 = 0.0
objective= 4190215.0
>>> 
>>> list(filter(bool, prob.variables()))
[x_0, x_1, x_10, x_11, x_12, x_13, x_14, x_2, x_3, x_4, x_5, x_6, x_7, x_8, x_9]
```
Using `bool` (after applying fix in #616) does not filter out interested variables correctly as the fundamental intention
is that each `LpVariable` object is assessed `True` by default.

Expected behaviour:
```python
$ python3.10 -i pulp/examples/test2.py

...

Status: Optimal
x_0 = 1.0
x_1 = 1.0
x_10 = 0.0
x_11 = 0.0
x_12 = 0.0
x_13 = 0.0
x_14 = 0.0
x_2 = 1.0
x_3 = 1.0
x_4 = 1.0
x_5 = 1.0
x_6 = 1.0
x_7 = 0.0
x_8 = 0.0
x_9 = 0.0
objective= 4190215.0
>>> 
>>> x_vars = prob.variables()
>>> x_vars[12] = None
>>> list(filter(bool, x_vars))
[x_0, x_1, x_2, x_3, x_4, x_5, x_6]
>>> 
```
as the implicit assessment will be:
```python
>>> list(map(bool, x_vars))
[True, True, False, False, False, False, False, True, True, True, True, True, False, False, False]
```


