### PR TITLE
Change behaviour of original bounds for Binary variables

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -264,8 +264,8 @@ class LpVariable(LpElement):
         self.varValue = None
         self.dj = None
         if cat == const.LpBinary:
-            self.lowBound = 0
-            self.upBound = 1
+            self._lowbound_original = self.lowBound = 0
+            self._upbound_original = self.upBound = 1
             self.cat = const.LpInteger
         # Code to add a variable to constraints for column based
         # modelling.


### PR DESCRIPTION
In Binary variables, if the inputs `lowBound` and `upBound` are the default None values, in the `__init__` the `self.lowBound` and `self.upBound` are set to 0,1. But the `self._lowbound_original`, `self._upbound_original` are set to None.  In the rest of the variables (Continuous, Integer) these two pairs of attributes coincide.

This is, the behaviour is equivalent to
```
self.lowBound = 0
self.upBound = 1
self._lowbound_original = None
self._upbound_original = None
```

It seems more consistent to have
```
self.lowBound = self._lowbound_original = 0
self.upBound = self._upbound_original  = 1
```

closes #620 