### PR TITLE
Add warm start, gap retrieval and better solution statuses for SCIP_PY (pyscipopt)

### DIFF
--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -710,3 +710,12 @@ class SCIP_PY(LpSolver):
             raise PulpSolverError(
                 f"The {self.name} solver does not implement resolving"
             )
+            
+        def getGap(self, lp):
+            """
+            Return SCIP's gap (in %), i.e. |(primalbound - dualbound)/min(|primalbound|,|dualbound|)|.
+            """
+            try:
+                return lp.solverModel.getGap() * 100
+            except AttributeError: # lp has no attribute solverModel, meaning self still has not optimized lp
+                raise PulpSolverError("This method can only be called after the optimization.")

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -567,7 +567,7 @@ class SCIP_PY(LpSolver):
                     if status == constants.LpStatusOptimal:
                         lp.assignStatus(status, constants.LpSolutionOptimal)
                     else :
-                        lp.assignStatus(status, constants.LpSolutionIntegerFeasible)
+                        lp.assignStatus(constants.LpStatusOptimal, constants.LpSolutionIntegerFeasible)
                 except: # No solution found
                     lp.assignStatus(status, constants.LpSolutionNoSolutionFound)
             else :

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -567,7 +567,8 @@ class SCIP_PY(LpSolver):
                     if status == constants.LpStatusOptimal:
                         lp.assignStatus(status, constants.LpSolutionOptimal)
                     else :
-                        lp.assignStatus(constants.LpStatusOptimal, constants.LpSolutionIntegerFeasible)
+                        status = constants.LpStatusOptimal
+                        lp.assignStatus(status, constants.LpSolutionIntegerFeasible)
                 except: # No solution found
                     lp.assignStatus(status, constants.LpSolutionNoSolutionFound)
             else :

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -186,7 +186,6 @@ class SCIP_CMD(LpSolver_CMD):
     def readsol(filename):
         """Read a SCIP solution file"""
         with open(filename) as f:
-
             # First line must contain 'solution status: <something>'
             try:
                 line = f.readline()
@@ -420,7 +419,6 @@ class FSCIP_CMD(LpSolver_CMD):
     def readsol(filename):
         """Read a FSCIP solution file"""
         with open(filename) as file:
-
             # First line must contain a solution status
             status_line = file.readline()
             status = FSCIP_CMD.parse_status(status_line)
@@ -469,7 +467,6 @@ class SCIP_PY(LpSolver):
     name = "SCIP_PY"
 
     try:
-
         global scip
         import pyscipopt as scip
 
@@ -544,19 +541,20 @@ class SCIP_PY(LpSolver):
                 "restartlimit": constants.LpStatusNotSolved,
                 "unknown": constants.LpStatusUndefined,
             }
-            possible_solution_found_statuses = ("optimal",
-                                                "timelimit",
-                                                "userinterrupt",
-                                                "nodelimit",
-                                                "totalnodelimit",
-                                                "stallnodelimit",
-                                                "gaplimit",
-                                                "memlimit",
+            possible_solution_found_statuses = (
+                "optimal",
+                "timelimit",
+                "userinterrupt",
+                "nodelimit",
+                "totalnodelimit",
+                "stallnodelimit",
+                "gaplimit",
+                "memlimit",
             )
             status = scip_to_pulp_status[solutionStatus]
-            
+
             if solutionStatus in possible_solution_found_statuses:
-                try: # Feasible solution found
+                try:  # Feasible solution found
                     solution = lp.solverModel.getBestSol()
                     for variable in lp._variables:
                         variable.varValue = solution[variable.solverVar]
@@ -566,14 +564,14 @@ class SCIP_PY(LpSolver):
                         )
                     if status == constants.LpStatusOptimal:
                         lp.assignStatus(status, constants.LpSolutionOptimal)
-                    else :
+                    else:
                         status = constants.LpStatusOptimal
                         lp.assignStatus(status, constants.LpSolutionIntegerFeasible)
-                except: # No solution found
+                except:  # No solution found
                     lp.assignStatus(status, constants.LpSolutionNoSolutionFound)
-            else :
-                lp.assignStatus(status)  
-            
+            else:
+                lp.assignStatus(status)
+
                 # TODO: check if problem is an LP i.e. does not have integer variables
                 # if :
                 #     for variable in lp._variables:
@@ -672,14 +670,15 @@ class SCIP_PY(LpSolver):
                     ),
                     name=name,
                 )
-                
+
             ##################################################
             # add warm start
             ##################################################
             if self.optionsDict.get("warmStart", False):
                 s = lp.solverModel.createPartialSol()
                 for var in lp.variables():
-                    if var.varValue is not None: # Warm start variables having an initial value
+                    if var.varValue is not None:
+                        # Warm start variables having an initial value
                         lp.solverModel.setSolVal(s, var.solverVar, var.varValue)
                 lp.solverModel.addSol(s)
 

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -496,6 +496,7 @@ class SCIP_PY(LpSolver):
             maxNodes=None,
             logPath=None,
             threads=None,
+            warmStart=False,
         ):
             """
             :param bool mip: if False, assume LP even if integer variables
@@ -507,6 +508,7 @@ class SCIP_PY(LpSolver):
             :param int maxNodes: max number of nodes during branching. Stops the solving when reached.
             :param str logPath: path to the log file
             :param int threads: sets the maximum number of threads
+            :param bool warmStart: if True, the solver will use the current value of variables as a start
             """
             super().__init__(
                 mip=mip,
@@ -518,6 +520,7 @@ class SCIP_PY(LpSolver):
                 maxNodes=maxNodes,
                 logPath=logPath,
                 threads=threads,
+                warmStart=warmStart,
             )
 
         def findSolutionValues(self, lp):
@@ -541,18 +544,35 @@ class SCIP_PY(LpSolver):
                 "restartlimit": constants.LpStatusNotSolved,
                 "unknown": constants.LpStatusUndefined,
             }
+            possible_solution_found_statuses = ("optimal",
+                                                "timelimit",
+                                                "userinterrupt",
+                                                "nodelimit",
+                                                "totalnodelimit",
+                                                "stallnodelimit",
+                                                "gaplimit",
+                                                "memlimit",
+            )
             status = scip_to_pulp_status[solutionStatus]
-            lp.assignStatus(status)
-
-            if status == constants.LpStatusOptimal:
-                solution = lp.solverModel.getBestSol()
-                for variable in lp._variables:
-                    variable.varValue = solution[variable.solverVar]
-                for constraint in lp.constraints.values():
-                    constraint.slack = lp.solverModel.getSlack(
-                        constraint.solverConstraint, solution
-                    )
-
+            
+            if solutionStatus in possible_solution_found_statuses:
+                try: # Feasible solution found
+                    solution = lp.solverModel.getBestSol()
+                    for variable in lp._variables:
+                        variable.varValue = solution[variable.solverVar]
+                    for constraint in lp.constraints.values():
+                        constraint.slack = lp.solverModel.getSlack(
+                            constraint.solverConstraint, solution
+                        )
+                    if status == constants.LpStatusOptimal:
+                        lp.assignStatus(status, constants.LpSolutionOptimal)
+                    else :
+                        lp.assignStatus(status, constants.LpSolutionIntegerFeasible)
+                except: # No solution found
+                    lp.assignStatus(status, constants.LpSolutionNoSolutionFound)
+            else :
+                lp.assignStatus(status)  
+            
                 # TODO: check if problem is an LP i.e. does not have integer variables
                 # if :
                 #     for variable in lp._variables:
@@ -651,6 +671,16 @@ class SCIP_PY(LpSolver):
                     ),
                     name=name,
                 )
+                
+            ##################################################
+            # add warm start
+            ##################################################
+            if self.optionsDict["warmStart"]:
+                s = lp.solverModel.createPartialSol()
+                for var in lp.variables():
+                    if var.varValue is not None: # Warm start variables having an initial value
+                        lp.solverModel.setSolVal(s, var.solverVar, var.varValue)
+                lp.solverModel.addSol(s)
 
         def actualSolve(self, lp):
             """

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -676,7 +676,7 @@ class SCIP_PY(LpSolver):
             ##################################################
             # add warm start
             ##################################################
-            if self.optionsDict["warmStart"]:
+            if self.optionsDict.get("warmStart", False):
                 s = lp.solverModel.createPartialSol()
                 for var in lp.variables():
                     if var.varValue is not None: # Warm start variables having an initial value
@@ -711,12 +711,3 @@ class SCIP_PY(LpSolver):
             raise PulpSolverError(
                 f"The {self.name} solver does not implement resolving"
             )
-            
-        def getGap(self, lp):
-            """
-            Return SCIP's gap (in %), i.e. |(primalbound - dualbound)/min(|primalbound|,|dualbound|)|.
-            """
-            try:
-                return lp.solverModel.getGap() * 100
-            except AttributeError: # lp has no attribute solverModel, meaning self still has not optimized lp
-                raise PulpSolverError("This method can only be called after the optimization.")


### PR DESCRIPTION
This PR aims to improve the `SCIP_PY` solver by :

1.  Adding a boolean `warmStart` parameter. When `True`, variables set to an initial value will be used by SCIP to fasten the optimization. In particular, one can warm start only a few variables, as SCIP does not need a complete solution to start from.
2. Improving the solution statuses when a MIP reaches time or gap limit, as such cases are currently returned as `LpStatusNotSolved`, even when a feasible (but non optimal solution) exists. This correction is pretty similar to that of #473 for `SCIP_CMD`*.
3. Adding a `getGap` method to retrieve SCIP's gap after an optimization. As SCIP is particularly verbose, I usually disable its logs, then using this method to still get a (concise) information about the optimization.


I have not made any unit test, but I have (sucessfully) tested those additions on a custom MIP on which I am working.


*Does anyone have any news about that PR ? It has been open for ~1 year and a half now, and looks almost complete...