### PR TITLE
Do not throw exception when HiGHS returns no solution

### DIFF
--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -187,8 +187,11 @@ class HiGHS_CMD(LpSolver_CMD):
                 constants.LpStatusUnbounded,
                 constants.LpSolutionNoSolutionFound,
             )
-        else:
-            raise PulpSolverError("Pulp: Error while executing", self.path)
+        else:  # no solution
+            status, status_sol = (
+                constants.LpStatusNotSolved,
+                constants.LpSolutionNoSolutionFound,
+            )
 
         if not os.path.exists(tmpSol) or os.stat(tmpSol).st_size == 0:
             status_sol = constants.LpSolutionNoSolutionFound


### PR DESCRIPTION
The interface currently throws an error when no solution is returned, while other interfaces return the `NotSolved` status.