### PR TITLE
Add option to set the number of threads for the CPLEX_PY API

### DIFF
--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -303,6 +303,7 @@ class CPLEX_PY(LpSolver):
             logPath=None,
             epgap=None,
             logfilename=None,
+            nthreads=0
         ):
             """
             :param bool mip: if False, assume LP even if integer variables
@@ -313,6 +314,7 @@ class CPLEX_PY(LpSolver):
             :param str logPath: path to the log file
             :param float epgap: deprecated for gapRel
             :param str logfilename: deprecated for logPath
+            :param int nthreads: number of threads to be used by CPLEX to solve a problem (default 0 uses all available)
             """
             if epgap is not None:
                 warnings.warn("Parameter epgap is being depreciated for gapRel")
@@ -337,6 +339,7 @@ class CPLEX_PY(LpSolver):
                 timeLimit=timeLimit,
                 warmStart=warmStart,
                 logPath=logPath,
+                threads=nthreads,
             )
 
         def available(self):
@@ -455,6 +458,7 @@ class CPLEX_PY(LpSolver):
                 self.changeEpgap(gapRel)
             if self.timeLimit is not None:
                 self.setTimeLimit(self.timeLimit)
+            self.setThreads(self.optionsDict.get("threads", 0))
             if self.optionsDict.get("warmStart", False):
                 # We assume "auto" for the effort_level
                 effort = self.solverModel.MIP_starts.effort_level.auto
@@ -477,6 +481,12 @@ class CPLEX_PY(LpSolver):
             self.solverModel.set_log_stream(fileobj)
             self.solverModel.set_warning_stream(fileobj)
             self.solverModel.set_results_stream(fileobj)
+
+        def setThreads(self, nthreads=0):
+            """
+            Change cplex thread count used (0 is default which uses all available resources)
+            """
+            self.solverModel.parameters.threads.set(nthreads)
 
         def changeEpgap(self, epgap=10**-4):
             """

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -303,7 +303,7 @@ class CPLEX_PY(LpSolver):
             logPath=None,
             epgap=None,
             logfilename=None,
-            threads=0
+            threads=None
         ):
             """
             :param bool mip: if False, assume LP even if integer variables
@@ -314,7 +314,7 @@ class CPLEX_PY(LpSolver):
             :param str logPath: path to the log file
             :param float epgap: deprecated for gapRel
             :param str logfilename: deprecated for logPath
-            :param int threads: number of threads to be used by CPLEX to solve a problem (default 0 uses all available)
+            :param int threads: number of threads to be used by CPLEX to solve a problem (default None uses all available)
             """
             if epgap is not None:
                 warnings.warn("Parameter epgap is being depreciated for gapRel")
@@ -458,7 +458,7 @@ class CPLEX_PY(LpSolver):
                 self.changeEpgap(gapRel)
             if self.timeLimit is not None:
                 self.setTimeLimit(self.timeLimit)
-            self.setThreads(self.optionsDict.get("threads", 0))
+            self.setThreads(self.optionsDict.get("threads", None))
             if self.optionsDict.get("warmStart", False):
                 # We assume "auto" for the effort_level
                 effort = self.solverModel.MIP_starts.effort_level.auto
@@ -482,11 +482,11 @@ class CPLEX_PY(LpSolver):
             self.solverModel.set_warning_stream(fileobj)
             self.solverModel.set_results_stream(fileobj)
 
-        def setThreads(self, threads=0):
+        def setThreads(self, threads=None):
             """
-            Change cplex thread count used (0 is default which uses all available resources)
+            Change cplex thread count used (None is default which uses all available resources)
             """
-            self.solverModel.parameters.threads.set(threads)
+            self.solverModel.parameters.threads.set(threads or 0)
 
         def changeEpgap(self, epgap=10**-4):
             """

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -303,7 +303,7 @@ class CPLEX_PY(LpSolver):
             logPath=None,
             epgap=None,
             logfilename=None,
-            nthreads=0
+            threads=0
         ):
             """
             :param bool mip: if False, assume LP even if integer variables
@@ -314,7 +314,7 @@ class CPLEX_PY(LpSolver):
             :param str logPath: path to the log file
             :param float epgap: deprecated for gapRel
             :param str logfilename: deprecated for logPath
-            :param int nthreads: number of threads to be used by CPLEX to solve a problem (default 0 uses all available)
+            :param int threads: number of threads to be used by CPLEX to solve a problem (default 0 uses all available)
             """
             if epgap is not None:
                 warnings.warn("Parameter epgap is being depreciated for gapRel")
@@ -339,7 +339,7 @@ class CPLEX_PY(LpSolver):
                 timeLimit=timeLimit,
                 warmStart=warmStart,
                 logPath=logPath,
-                threads=nthreads,
+                threads=threads,
             )
 
         def available(self):
@@ -482,11 +482,11 @@ class CPLEX_PY(LpSolver):
             self.solverModel.set_warning_stream(fileobj)
             self.solverModel.set_results_stream(fileobj)
 
-        def setThreads(self, nthreads=0):
+        def setThreads(self, threads=0):
             """
             Change cplex thread count used (0 is default which uses all available resources)
             """
-            self.solverModel.parameters.threads.set(nthreads)
+            self.solverModel.parameters.threads.set(threads)
 
         def changeEpgap(self, epgap=10**-4):
             """


### PR DESCRIPTION
Adapted from #528, this is a PR to resolve #457, simply adding an option to control the number of threads used by CPLEX. Please let me know, what (if anything) needs to be changed. Thanks!