### PR TITLE
Add test to expose breaking change

### DIFF
--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -795,6 +795,29 @@ class BaseSolverTest:
             else:
                 pulpTestCheck(prob, self.solver, [const.LpStatusUnbounded])
 
+        def test_msg_arg(self):
+            """
+            Test setting the msg arg to True does not interfere with solve
+            """
+            prob = LpProblem("test_msg_arg", const.LpMinimize)
+            x = LpVariable("x", 0, 4)
+            y = LpVariable("y", -1, 1)
+            z = LpVariable("z", 0)
+            w = LpVariable("w", 0)
+            prob += x + 4 * y + 9 * z, "obj"
+            prob += x + y <= 5, "c1"
+            prob += x + z >= 10, "c2"
+            prob += -y + z == 7, "c3"
+            prob += w >= 0, "c4"
+            data = prob.toDict()
+            var1, prob1 = LpProblem.fromDict(data)
+            x, y, z, w = (var1[name] for name in ["x", "y", "z", "w"])
+
+            self.solver.msg = True
+            pulpTestCheck(
+                prob1, self.solver, [const.LpStatusOptimal], {x: 4, y: -1, z: 6, w: 0}
+            )
+
         def test_pulpTestAll(self):
             """
             Test the availability of the function pulpTestAll


### PR DESCRIPTION
There's a breaking change in master for Highs API, but I can't demo it on this repo because all Highs tests are being skipped (from resolving the numpy issue). When adding back the Highs tests (e.g. per [this PR](https://github.com/coin-or/pulp/pull/677)), I can demonstrate the below issue.

---

@siwy @pchtsp From this PR (https://github.com/coin-or/pulp/pull/606), the introduction of setLogCallback seems to be a breaking change for any model using the Highs API solver with msg=True. Running a simple model locally

```bash
File "/Users/aphi/repo/pulp/pulp/apis/highs_api.py", line 301, in createAndConfigureSolver
    lp.solverModel.setLogCallback(*callbackTuple)
AttributeError: 'Highs' object has no attribute 'setLogCallback'
```

Within the Highs source code, I don't think setLogCallback is exposed to Python since it's in `Highs.cpp` but not `highs_bindings.cpp` for highspy, so won't be accessible without that modified bindings file.

The CI tests didn't pick it up since this code path requires self.msg to be True, and it's set as always False in BaseSolverTest (line 53 of test_pulp.py).

This PR adds a simple test with msg=True to demonstrate the failing test, and to improve the test coverage.