### PR TITLE
Add back highspy test, with numpy included

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Install gurobipy
         run: |
           python -m pip install gurobipy
-#      - name: Install highspy
-#        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
-#        run: |
-#          pip install highspy
+      - name: Install highspy
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+        run: |
+          pip install highspy numpy
       - name: Test with pulptest
         run: pulptest
       - name: Code Quality

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 21
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
Right now we're not testing the highs api solver. It was removed from the test script because it was failing because Highspy depends on Numpy under the hood. (E.g. inside pybind11 within highs_bindings.cpp)

This PR adds it back, including numpy, which resolves the issue.

The HiGHS documentation recommends numpy as a likely dependency here: https://github.com/ERGO-Code/HiGHS/blob/master/docs/src/interfaces/python/index.md