### PR TITLE
Bugfix/scip option parsing

### DIFF
--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -135,7 +135,7 @@ class HiGHS_CMD(LpSolver_CMD):
                 option += f"={next(options)}"
 
             # identify cli options by a leading dash (-) and treat other options as file options
-            if option.starts_with("-"):
+            if option.startswith("-"):
                 command.append(option)
             else:
                 file_options.append(option)

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -333,7 +333,7 @@ class FSCIP_CMD(LpSolver_CMD):
         options = iter(self.options)
         for option in options:
             # identify cli options by a leading dash (-) and treat other options as file options
-            if option.starts_with("-"):
+            if option.startswith("-"):
                 # assumption: all cli options require an argument which is provided as a separate parameter
                 argument = next(options)
                 command.extend([option, argument])

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -148,7 +148,7 @@ class SCIP_CMD(LpSolver_CMD):
         options = iter(self.options)
         for option in options:
             # identify cli options by a leading dash (-) and treat other options as file options
-            if option.starts_with("-"):
+            if option.startswith("-"):
                 # assumption: all cli options require an argument which is provided as a separate parameter
                 argument = next(options)
                 command.extend([option, argument])

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -1399,6 +1399,37 @@ class BaseSolverTest:
             # it should be all None
             self.assertTrue(all(c is None for c in shadowPrices.values()))
 
+        def test_options_parsing_SCIP_HIGHS(self):
+            name = self._testMethodName
+            prob = LpProblem(name, const.LpMinimize)
+            x = LpVariable("x", 0, 4)
+            y = LpVariable("y", -1, 1)
+            z = LpVariable("z", 0)
+            w = LpVariable("w", 0)
+            prob += x + 4 * y + 9 * z, "obj"
+            prob += x + y <= 5, "c1"
+            prob += x + z >= 10, "c2"
+            prob += -y + z == 7, "c3"
+            prob += w >= 0, "c4"
+            # CHOCO has issues when given a time limit
+            print("\t Testing options parsing")
+            if self.solver.__class__ in [SCIP_CMD, FSCIP_CMD]:
+                self.solver.options = ["limits/time", 20]
+                pulpTestCheck(
+                    prob,
+                    self.solver,
+                    [const.LpStatusOptimal],
+                    {x: 4, y: -1, z: 6, w: 0},
+                )
+            elif self.solver.__class__ in [HiGHS_CMD]:
+                self.solver.options = ["time_limit", 20]
+                pulpTestCheck(
+                    prob,
+                    self.solver,
+                    [const.LpStatusOptimal],
+                    {x: 4, y: -1, z: 6, w: 0},
+                )
+
 
 class PULP_CBC_CMDTest(BaseSolverTest.PuLPTest):
     solveInst = PULP_CBC_CMD


### PR DESCRIPTION
`SCIP_CMD` and `HiGHS_CMD` where using `starts_with()` for the option parsing, when the correct method is `startswith()`.
Made the change and added a test to make sure that options parsing works correctly (test is the same as the time limit one but passing the time limit in the options list).