### PR TITLE
Fix error in HiGHS interface for infeasible/unbounded solutions

### DIFF
--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -203,11 +203,11 @@ class HiGHS_CMD(LpSolver_CMD):
         if not os.path.exists(tmpSol) or os.stat(tmpSol).st_size == 0:
             status_sol = constants.LpSolutionNoSolutionFound
             values = None
-        elif (
-            status_sol == constants.LpSolutionNoSolutionFound
-            or status_sol == constants.LpSolutionInfeasible
-            or status_sol == constants.LpSolutionUnbounded
-        ):
+        elif status_sol in {
+            constants.LpSolutionNoSolutionFound,
+            constants.LpSolutionInfeasible,
+            constants.LpSolutionUnbounded,
+        }:
             values = None
         else:
             values = self.readsol(tmpSol)

--- a/pulp/apis/highs_api.py
+++ b/pulp/apis/highs_api.py
@@ -203,7 +203,11 @@ class HiGHS_CMD(LpSolver_CMD):
         if not os.path.exists(tmpSol) or os.stat(tmpSol).st_size == 0:
             status_sol = constants.LpSolutionNoSolutionFound
             values = None
-        elif status_sol == constants.LpSolutionNoSolutionFound:
+        elif (
+            status_sol == constants.LpSolutionNoSolutionFound
+            or status_sol == constants.LpSolutionInfeasible
+            or status_sol == constants.LpSolutionUnbounded
+        ):
             values = None
         else:
             values = self.readsol(tmpSol)


### PR DESCRIPTION
Currently the following problem:

```py
from pulp import *

problem = LpProblem("infeasible", LpMaximize)

# Infeasible problem
x = LpVariable("x", 0, 1)
y = LpVariable("y", 0, 1)
problem += x <= -1

solver = HiGHS_CMD(timeLimit=1, msg=1)

problem.solve(solver)
```

results in an error `pulp.apis.core.PulpSolverError: Cannot read HiGHS solver output` (line 253 of `highs_api.py`).

This error appeared after b0856c2c2ae9e1c4e2d3df5f0637363129743896, which sets the solution status for infeasible/unbounded problems. This PR fixes the attempt to read the solution in those cases.
