### PR TITLE
handle PL bounds and include test

### DIFF
--- a/pulp/mps_lp.py
+++ b/pulp/mps_lp.py
@@ -175,6 +175,9 @@ def readMPSSetBounds(line, variable_dict):
     elif bound == "BV":
         set_both_bounds(0, 1)
         return
+    elif bound == "PL":
+        # bounds equal to defaults
+        return
     value = float(line[3])
     if bound in ["LO", "UP"]:
         set_one_bound(bound, value)

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -42,6 +42,10 @@ BOUNDS
 ENDATA
 """
 
+EXAMPLE_MPS_PL_BOUNDS = EXAMPLE_MPS_RHS56.replace(
+    "LO BND1      YTWO                -1", "PL BND1      YTWO                  "
+)
+
 
 def gurobi_test(test_item):
     @functools.wraps(test_item)
@@ -1207,6 +1211,15 @@ class BaseSolverTest:
             _, problem = LpProblem.fromMPS(h.name)
             os.unlink(h.name)
             self.assertEqual(problem.constraints["LIM2"].constant, -10)
+
+        def test_importMPS_PL_bound(self):
+            """Import MPS file with PL bound type."""
+            with tempfile.NamedTemporaryFile(delete=False) as h:
+                h.write(str.encode(EXAMPLE_MPS_PL_BOUNDS))
+            print("\t Testing reading MPS files - PL bound")
+            _, problem = LpProblem.fromMPS(h.name)
+            os.unlink(h.name)
+            self.assertIsInstance(problem, LpProblem)
 
         # def test_importMPS_2(self):
         #     name = self._testMethodName


### PR DESCRIPTION
Fixes #635. 

Some software writes MPS-files including PL bounds, but without a value. When reading these lines the `readMPSSetBounds` raises an `IndexError`, when trying to read the value. 

PL-bounds can be ignored. This PR implements a case in the `readMPSSetBounds` to ignore the PL-type bounds. 

Next to that a test is added, to test whether a MPS-file containing a PL-bound can be read. 