### PR TITLE
Fix detection of osx-arm64

### DIFF
--- a/pulp/apis/core.py
+++ b/pulp/apis/core.py
@@ -163,7 +163,6 @@ if sys.platform in ["win32", "cli"]:
     PULPCFGFILE += ".win"
 elif sys.platform in ["darwin"]:
     operating_system = "osx"
-    arch = "64"
     PULPCFGFILE += ".osx"
 else:
     operating_system = "linux"


### PR DESCRIPTION
Currently the code assumes all Darwin aka osx aka maxOS machines are Intel 64 bit. With this change pulp will no look for a solver at ``pulp/solverdir/cbc/osx/arm64/cbc`` and works correctly on an Apple M3 ARM CPU.

This was tested with the pre-compiled binary extracted from ``Cbc-arm64-macos14-gcc1330.tar.gz`` at https://github.com/coin-or/Cbc/actions/runs/10332640644 at the suggestion of one of the cbc maintainers, @tkralphs in conversation on a linked issue here: https://github.com/conda-forge/pulp-feedstock/issues/27#issuecomment-2285782785

```
$ md5 pulp/solverdir/cbc/osx/arm64/cbc
MD5 (pulp/solverdir/cbc/osx/arm64/cbc) = 6b4b1b8849cac7ed5574166f6a8586d8
$ shasum -a 256 pulp/solverdir/cbc/osx/arm64/cbc
6e3cfc1d1bd5294d61279fb52dd21590653a4da2eb0472b651577ec860f699bb  pulp/solverdir/cbc/osx/arm64/cbc
```

I am happy to add that exact binary ``cbc`` to this pull request which was built from https://github.com/coin-or/Cbc/commit/50c612fe9ce5c31f4b0be9dde4cc0b8f7d6e018b (master branch 10 August) which I presume is 2.10.11 plus work since. There have been a couple of newer builds since - I don' know when the next release is planned.