### PR TITLE
add test / fix for lpdot

### DIFF
--- a/pulp/constants.py
+++ b/pulp/constants.py
@@ -87,15 +87,6 @@ LpConstraintSenses = {LpConstraintEQ: "=", LpConstraintLE: "<=", LpConstraintGE:
 LpCplexLPLineSize = 78
 
 
-def isiterable(obj):
-    try:
-        obj = iter(obj)
-    except:
-        return False
-    else:
-        return True
-
-
 class PulpError(Exception):
     """
     Pulp Exception Class

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -2233,16 +2233,17 @@ def lpSum(vector):
     return LpAffineExpression().addInPlace(vector)
 
 
-def lpDot(v1, v2):
-    v1_iterable = const.isiterable(v1) and not isinstance(v1, LpAffineExpression)
-    v2_iterable = const.isiterable(v2) and not isinstance(v2, LpAffineExpression)
+def _vector_like(obj):
+    return isinstance(obj, Iterable) and not isinstance(obj, LpAffineExpression)
 
+
+def lpDot(v1, v2):
     """Calculate the dot product of two lists of linear expressions"""
-    if not v1_iterable and not v2_iterable:
+    if not _vector_like(v1) and not _vector_like(v2):
         return v1 * v2
-    elif not v1_iterable:
+    elif not _vector_like(v1):
         return lpDot([v1] * len(v2), v2)
-    elif not v2_iterable:
+    elif not _vector_like(v2):
         return lpDot(v1, [v2] * len(v1))
     else:
         return lpSum([lpDot(e1, e2) for e1, e2 in zip(v1, v2)])

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -2234,12 +2234,15 @@ def lpSum(vector):
 
 
 def lpDot(v1, v2):
+    v1_iterable = const.isiterable(v1) and not isinstance(v1, LpAffineExpression)
+    v2_iterable = const.isiterable(v2) and not isinstance(v2, LpAffineExpression)
+
     """Calculate the dot product of two lists of linear expressions"""
-    if not const.isiterable(v1) and not const.isiterable(v2):
+    if not v1_iterable and not v2_iterable:
         return v1 * v2
-    elif not const.isiterable(v1):
+    elif not v1_iterable:
         return lpDot([v1] * len(v2), v2)
-    elif not const.isiterable(v2):
+    elif not v2_iterable:
         return lpDot(v1, [v2] * len(v1))
     else:
         return lpSum([lpDot(e1, e2) for e1, e2 in zip(v1, v2)])

--- a/pulp/tests/test_lpdot.py
+++ b/pulp/tests/test_lpdot.py
@@ -6,3 +6,17 @@ def test_lpdot():
 
     product = lpDot(1, 2 * x)
     assert product.toDict() == [{"name": "x", "value": 2}]
+
+
+def test_pulp_002():
+    """
+    Test the lpDot operation
+    """
+    x = LpVariable("x")
+    y = LpVariable("y")
+    z = LpVariable("z")
+    a = [1, 2, 3]
+    assert dict(lpDot([x, y, z], a)) == {x: 1, y: 2, z: 3}
+    assert dict(lpDot([2 * x, 2 * y, 2 * z], a)) == {x: 2, y: 4, z: 6}
+    assert dict(lpDot([x + y, y + z, z], a)) == {x: 1, y: 3, z: 5}
+    assert dict(lpDot(a, [x + y, y + z, z])) == {x: 1, y: 3, z: 5}

--- a/pulp/tests/test_lpdot.py
+++ b/pulp/tests/test_lpdot.py
@@ -1,0 +1,8 @@
+from pulp import lpDot, LpVariable
+
+
+def test_lpdot():
+    x = LpVariable(name="x")
+
+    product = lpDot(1, 2 * x)
+    assert product.toDict() == [{"name": "x", "value": 2}]


### PR DESCRIPTION
Without the change to `lpdot`, this new test fails with 

```
E       AssertionError: assert [{'name': 'x', 'value': 1}] == [{'name': 'x', 'value': 2}]
E         
E         At index 0 diff: {'name': 'x', 'value': 1} != {'name': 'x', 'value': 2}
E         Use -v to get more diff
```

The `lpdot` function uses `isiterable` to check for "vector" types, however an `LpAffineExpression` is iterable.