### PR TITLE
HiGHS API: Add duals, slacks, reduced costs (#780)

### DIFF
--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -613,6 +613,7 @@ class BaseSolverTest:
                 PULP_CBC_CMD,
                 YAPOSIB,
                 PYGLPK,
+                HiGHS,
             ]:
                 pulpTestCheck(
                     prob,


### PR DESCRIPTION
This adds duals, slacks, and reduced costs to the highspy HiGHS interface.

Closes: #780