### PR TITLE
Add support for bound type `MI` in `pulp.LpProblem.fromMPS`

### DIFF
--- a/pulp/mps_lp.py
+++ b/pulp/mps_lp.py
@@ -5,6 +5,7 @@
 """
 
 import re
+
 from . import constants as const
 
 CORE_FILE_ROW_MODE = "ROWS"
@@ -177,6 +178,9 @@ def readMPSSetBounds(line, variable_dict):
         return
     elif bound == "PL":
         # bounds equal to defaults
+        return
+    elif bound == "MI":
+        set_one_bound("LO", None)
         return
 
     value = float(line[3])


### PR DESCRIPTION
Adds support for `MI` bounded variables in the `pulp.LpProblem.fromMPS` method . 

This addresses Issue #791.

Changes
------------

Added an additional clause to `readMPSSetBounds` in `pulp.mps_lp`.

```
def readMPSSetBounds(line, variable_dict):
    bound = line[0]
    var_name = line[2]

    def set_one_bound(bound_type, value):
        variable_dict[var_name][BOUNDS_EQUIV[bound_type]] = value

    def set_both_bounds(value_low, value_up):
        set_one_bound("LO", value_low)
        set_one_bound("UP", value_up)

    if bound == "FR":
        set_both_bounds(None, None)
        return
    elif bound == "BV":
        set_both_bounds(0, 1)
        return
    elif bound == "PL":
        # bounds equal to defaults
        return
    elif bound == "MI":
        # Lower bound -inf
        set_one_bound("LO", None)
        return

    value = float(line[3])
    if bound in ["LO", "UP"]:
        set_one_bound(bound, value)
    elif bound == "FX":
        set_both_bounds(value, value)
    return
```

Added a test to `BaseSolverTest.PuLPTest` called `test_importMPF_MI_bound`, which is similar in form to the existing `test_importMPS_PL_bound` method. An additional global variable is created, called `EXAMPLE_MPS_MI_BOUNDS` which is similar in form to the existing `EXAMPLE_MPS_PL_BOUNDS` variable.

Tests pass on Windows 11, with the `PULP_CBC_CMD` solver. Additional testing with more solvers is requested.

Documentation was re-built, but no changes are present.

`isort` also cleaned up the order of imports in each of the changed files. Let me know if this was inappropriate. 

Next Steps
------------

Testing with additional solvers should be considered by those more familiar with the project. I do not have licensing for most of the supported solvers so that testing was not done on my part. However, this change doesn't touch any of the library related to the solver APIs.  