### PR TITLE
Fix warning message

### DIFF
--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -1790,7 +1790,7 @@ class PULP_CBC_CMDTest(BaseSolverTest.PuLPTest):
         'off'
 
         >>> cmd = "cbc model.mps -strong 101 -timeMode elapsed -branch"
-        >>> PULP_CBC_CMDTest.extract_option_from_command_line(cmd, "strong", grp_pattern="\d+")
+        >>> PULP_CBC_CMDTest.extract_option_from_command_line(cmd, "strong", grp_pattern="\\d+")
         '101'
         """
         pattern = re.compile(rf"{prefix}{option}\s+({grp_pattern})\s*")
@@ -1947,7 +1947,7 @@ class PULP_CBC_CMDTest(BaseSolverTest.PuLPTest):
         # Extract option value from command line
         command_line = PULP_CBC_CMDTest.read_command_line_from_log_file(logFilename)
         option_value = PULP_CBC_CMDTest.extract_option_from_command_line(
-            command_line, option="strong", grp_pattern="\d+"
+            command_line, option="strong", grp_pattern="\\d+"
         )
         self.assertEqual("10", option_value)
 


### PR DESCRIPTION
Right now there's a slightly confronting warning message that shows up the first time you import pulp.

Under the hood it's caused by the first time you compile the test code. (Only the first time, but you can reinvoke it if you delete the `pulp/tests/__pycache__`)
e.g.
```
$ uv add pulp==3.0.2            
Resolved 108 packages in 11ms
Installed 1 package in 2ms
 + pulp==3.0.2
$ uv run python
Python 3.12.8 (main, Jan  9 2025, 13:27:20) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pulp
/Users/antony/repo/data-analysis/.venv/lib/python3.12/site-packages/pulp/tests/test_pulp.py:1776: SyntaxWarning: invalid escape sequence '\d'
  """
/Users/antony/repo/data-analysis/.venv/lib/python3.12/site-packages/pulp/tests/test_pulp.py:1950: SyntaxWarning: invalid escape sequence '\d'
  command_line, option="strong", grp_pattern="\d+"
>>> 
```

I want to fix this just so it's a better experience for new users of pulp.

This PR fixes those warnings by escaping those characters correctly.