### PR TITLE
SCIP returns LpStatusUnbounded when the problem is unbounded

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -67,5 +67,8 @@ jobs:
       - name: Install swat
         run: |
           python -m pip install swat
+      - name: Install SCIP_PY
+        run: |
+          python -m pip install pyscipopt
       - name: Test with pulptest
         run: pulptest

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -835,7 +835,7 @@ class BaseSolverTest:
             elif self.solver.__class__ is GLPK_CMD:
                 # GLPK_CMD Does not report unbounded problems, correctly
                 pulpTestCheck(prob, self.solver, [const.LpStatusUndefined])
-            elif self.solver.__class__ in [GUROBI_CMD, SCIP_CMD, FSCIP_CMD, SCIP_PY]:
+            elif self.solver.__class__ in [GUROBI_CMD, FSCIP_CMD]:
                 pulpTestCheck(prob, self.solver, [const.LpStatusNotSolved])
             elif self.solver.__class__ in [CHOCO_CMD]:
                 # choco bounds all variables. Would not return unbounded status


### PR DESCRIPTION
SCIP appears to identify when a solution is unbounded, so test for the correct return code.

Fixes one of the tests in #799.