### PR TITLE
Type hints

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,11 +8,8 @@ jobs:
     strategy:
       max-parallel: 21
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        exclude:
-          - os: macOS-latest
-            python-version: '3.8'
 
     steps:
       - uses: actions/checkout@v4

--- a/INSTALL
+++ b/INSTALL
@@ -4,7 +4,7 @@ Installation
 Note that to install PuLP you must first have a working python installation as
 described in `installing python`_.
 
-PuLP requires Python >= 2.7 or Python >= 3.4.
+PuLP requires Python >= 3.9.
 
 The latest version of PuLP can be freely obtained from github_.
 
@@ -15,7 +15,7 @@ By far the easiest way to install pulp is through the use of pip_.
 
 * In  windows (please make sure pip is on your path)::
 
-    c:\Python34\Scripts\> pip install pulp
+    c:\Python39\Scripts\> pip install pulp
 
 * In Linux::
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ PuLP is part of the `COIN-OR project <https://www.coin-or.org/>`_.
 Installation
 ================
 
-PuLP requires Python 3.7 or newer.
+PuLP requires Python 3.9 or newer.
 
 The easiest way to install PuLP is with ``pip``. If ``pip`` is available on your system, type::
 

--- a/examples/AmericanSteelProblem.py
+++ b/examples/AmericanSteelProblem.py
@@ -50,7 +50,7 @@ Arcs = [
     ("Chicago", "Gary"),
 ]
 
-arcData = {  #      ARC                Cost Min Max
+arcData: dict[tuple[str, str], list[float]] = {  #      ARC                Cost Min Max
     ("Youngstown", "Albany"): [0.5, 0, 1000],
     ("Youngstown", "Cincinatti"): [0.35, 0, 3000],
     ("Youngstown", "Kansas City"): [0.45, 1000, 5000],
@@ -72,7 +72,7 @@ arcData = {  #      ARC                Cost Min Max
 (costs, mins, maxs) = splitDict(arcData)
 
 # Creates the boundless Variables as Integers
-vars = LpVariable.dicts("Route", Arcs, None, None, LpInteger)
+vars = LpVariable.dicts("Route", Arcs, cat=LpInteger)
 
 # Creates the upper and lower bounds on the variables
 for a in Arcs:

--- a/examples/SpongeRollProblem2.py
+++ b/examples/SpongeRollProblem2.py
@@ -10,10 +10,10 @@ from pulp import *
 # A list of all the roll lengths is created
 LenOpts = ["5", "7", "9"]
 
-rollData = {  # Length Demand SalePrice
-    "5": [150, 0.25],
-    "7": [200, 0.33],
-    "9": [300, 0.40],
+rollData: dict[str, tuple[int, float]] = {  # Length Demand SalePrice
+    "5": (150, 0.25),
+    "7": (200, 0.33),
+    "9": (300, 0.40),
 }
 
 # A list of all the patterns is created

--- a/examples/SpongeRollProblem3.py
+++ b/examples/SpongeRollProblem3.py
@@ -5,7 +5,7 @@ Authors: Antony Phillips, Dr Stuart Mitchell    2007
 """
 
 
-def calculatePatterns(totalRollLength, lenOpts, head):
+def calculatePatterns(totalRollLength: int, lenOpts: list[int], head: list[int]):
     """
     Recursively calculates the list of options lists for a cutting stock problem. The input
     'tlist' is a pointer, and will be the output of the function call.
@@ -20,7 +20,7 @@ def calculatePatterns(totalRollLength, lenOpts, head):
     Authors: Bojan Blazevic, Dr Stuart Mitchell    2007
     """
     if lenOpts:
-        patterns = []
+        patterns: list[list[int]] = []
         # take the first option off lenOpts
         opt = lenOpts[0]
         for rep in range(int(totalRollLength / opt) + 1):
@@ -36,7 +36,7 @@ def calculatePatterns(totalRollLength, lenOpts, head):
     return patterns
 
 
-def makePatterns(totalRollLength, lenOpts):
+def makePatterns(totalRollLength: int, lenOpts: list[int]):
     """
     Makes the different cutting patterns for a cutting stock problem.
 
@@ -51,13 +51,12 @@ def makePatterns(totalRollLength, lenOpts):
     patterns = calculatePatterns(totalRollLength, lenOpts, [])
 
     # The list 'PatternNames' is created
-    PatternNames = []
-    for i in range(len(patterns)):
-        PatternNames += ["P" + str(i)]
+    PatternNames = [f"P{i}" for i in range(len(patterns))]
+
 
     # The amount of trim (unused material) for each pattern is calculated and added to the dictionary
     # 'trim', with the reference key of the pattern name.
-    trim = {}
+    trim: dict[str, int] = {}
     for name, pattern in zip(PatternNames, patterns):
         ssum = 0
         for rep, l in zip(pattern, lenOpts):
@@ -69,7 +68,7 @@ def makePatterns(totalRollLength, lenOpts):
     for name, pattern in zip(PatternNames, patterns):
         print(name + f"  = {pattern}")
 
-    return (PatternNames, patterns, trim)
+    return PatternNames, patterns, trim
 
 
 # Import PuLP modeler functions
@@ -87,7 +86,7 @@ trimValue = 0.04
 # A list of all the roll lengths is created
 LenOpts = ["5", "7", "9"]
 
-rollData = {  # Length Demand SalePrice
+rollData: dict[str, list[int | float]] = {  # Length Demand SalePrice
     "5": [150, 0.25],
     "7": [200, 0.33],
     "9": [300, 0.40],

--- a/examples/SpongeRollProblem4.py
+++ b/examples/SpongeRollProblem4.py
@@ -5,7 +5,7 @@ Authors: Antony Phillips, Dr Stuart Mitchell    2007
 """
 
 
-def calculatePatterns(totalRollLength, lenOpts, head):
+def calculatePatterns(totalRollLength: int, lenOpts: list[int], head: list[int]):
     """
     Recursively calculates the list of options lists for a cutting stock problem. The input
     'tlist' is a pointer, and will be the output of the function call.
@@ -20,7 +20,7 @@ def calculatePatterns(totalRollLength, lenOpts, head):
     Authors: Bojan Blazevic, Dr Stuart Mitchell    2007
     """
     if lenOpts:
-        patterns = []
+        patterns: list[list[int]] = []
         # take the first option off lenOpts
         opt = lenOpts[0]
         for rep in range(int(totalRollLength / opt) + 1):
@@ -36,7 +36,7 @@ def calculatePatterns(totalRollLength, lenOpts, head):
     return patterns
 
 
-def makePatterns(totalRollLength, lenOpts):
+def makePatterns(totalRollLength: int, lenOpts: list[int]):
     """
     Makes the different cutting patterns for a cutting stock problem.
 
@@ -51,15 +51,13 @@ def makePatterns(totalRollLength, lenOpts):
     patternslist = calculatePatterns(totalRollLength, lenOpts, [])
 
     # The list 'PatternNames' is created
-    PatternNames = []
-    for i in range(len(patternslist)):
-        PatternNames += ["P" + str(i)]
+    PatternNames = [f"P{i}" for i in range(len(patternslist))]
 
     # Patterns = [0 for i in range(len(PatternNames))]
-    Patterns = []
-
-    for i, j in enumerate(PatternNames):
-        Patterns += [Pattern(j, patternslist[i])]
+    Patterns = [
+        Pattern(j, patternslist[i])
+        for i, j in enumerate(PatternNames)
+    ]
 
     # The different cutting lengths are printed, and the number of each roll of that length in each
     # pattern is printed below. This is so the user can see what each pattern contains.
@@ -80,7 +78,7 @@ class Pattern:
     totalRollLength = 20
     lenOpts = [5, 7, 9]
 
-    def __init__(self, name, lengths=None):
+    def __init__(self, name: str, lengths: list[int]):
         self.name = name
         self.lengthsdict = dict(zip(self.lenOpts, lengths))
 
@@ -96,7 +94,12 @@ class Pattern:
 # Import PuLP modeler functions
 from pulp import *
 
-rollData = {5: [150, 0.25], 7: [200, 0.33], 9: [300, 0.40]}  # Length Demand SalePrice
+# Length Demand SalePrice
+rollData: dict[int, tuple[int, float]] = {
+    5: (150, 0.25),
+    7: (200, 0.33),
+    9: (300, 0.40),
+}
 
 # The pattern names and the patterns are created as lists, and the associated trim with each pattern
 # is created as a dictionary. The inputs are the total roll length and the list (as integers) of

--- a/examples/SpongeRollProblem5.py
+++ b/examples/SpongeRollProblem5.py
@@ -8,10 +8,10 @@ Authors: Antony Phillips,  Dr Stuart Mitchell  2008
 from .CG import *
 
 # The roll data is created
-rollData = {  # Length Demand SalePrice
-    "5": [150, 0.25],
-    "7": [200, 0.33],
-    "9": [300, 0.40],
+rollData: dict[str, tuple[int, float]] = {  # Length Demand SalePrice
+    "5": (150, 0.25),
+    "7": (200, 0.33),
+    "9": (300, 0.40),
 }
 
 # The boolean variable morePatterns is set to True to test for more patterns
@@ -21,23 +21,24 @@ morePatterns = True
 patternslist = [[4, 0, 0], [0, 2, 0], [0, 0, 2]]
 
 # The starting patterns are instantiated with the Pattern class
-Patterns = []
-for i in patternslist:
-    Patterns += [Pattern("P" + str(len(Patterns)), i)]
+patterns = [
+    Pattern(f"P{i}", li)
+    for i, li in enumerate(patternslist)
+]
 
 # This loop will be repeated until morePatterns is set to False
-while morePatterns == True:
+while morePatterns:
     # Solve the problem as a Relaxed LP
-    duals = masterSolve(Patterns, rollData)
+    duals = masterSolve(patterns, rollData)
 
     # Find another pattern
-    Patterns, morePatterns = subSolve(Patterns, duals)
+    patterns, morePatterns = subSolve(patterns, duals)
 
 # Re-solve as an Integer Problem
-solution, varsdict = masterSolve(Patterns, rollData, relax=False)
+solution, varsdict = masterSolve(patterns, rollData, relax=False)
 
 # Display Solution
-for i, j in list(varsdict.items()):
+for i, j in varsdict.items():
     print(i, "=", j)
 
 print("objective = ", solution)

--- a/examples/SpongeRollProblem6.py
+++ b/examples/SpongeRollProblem6.py
@@ -27,7 +27,7 @@ while newPatterns:
 solution, varsdict = masterSolve(prob, relax=False)
 
 # Display Solution
-for i, j in list(varsdict.items()):
+for i, j in varsdict.items():
     print(i, "=", j)
 
 print("objective = ", solution)

--- a/examples/Sudoku1.py
+++ b/examples/Sudoku1.py
@@ -9,7 +9,7 @@ edited by Nathan Sudermann-Merx
 from pulp import *
 
 # All rows, columns and values within a Sudoku take values from 1 to 9
-VALS = ROWS = COLS = range(1, 10)
+VALS = ROWS = COLS = list(range(1, 10))
 
 # The boxes list is created, with the row and column index of each square in each box
 Boxes = [

--- a/examples/Sudoku2.py
+++ b/examples/Sudoku2.py
@@ -9,7 +9,7 @@ edited by Dr Nathan Sudermann-Merx
 from pulp import *
 
 # All rows, columns and values within a Sudoku take values from 1 to 9
-VALS = ROWS = COLS = range(1, 10)
+VALS = ROWS = COLS = list(range(1, 10))
 
 # The boxes list is created, with the row and column index of each square in each box
 Boxes = [

--- a/examples/Two_stage_Stochastic_GemstoneTools.py
+++ b/examples/Two_stage_Stochastic_GemstoneTools.py
@@ -32,7 +32,7 @@ import pulp
 # parameters
 products = ["wrenches", "pliers"]
 price = [130, 100]
-steel = [1.5, 1]
+steel = [1.5, 1.0]
 molding = [1, 1]
 assembly = [0.3, 0.5]
 capsteel = 27

--- a/examples/furniture.py
+++ b/examples/furniture.py
@@ -9,12 +9,12 @@ Chairs = ["A", "B"]
 costs = {"A": 100, "B": 150}
 Resources = ["Lathe", "Polisher"]
 capacity = {"Lathe": 40, "Polisher": 48}
-activity = [  # Chairs
+activity_list: list[list[int | float]] = [  # Chairs
     # A  B
     [1, 2],  # Lathe
     [3, 1.5],  # Polisher
 ]
-activity = makeDict([Resources, Chairs], activity)
+activity = makeDict([Resources, Chairs], activity_list)
 prob = LpProblem("Furniture Manufacturing Problem", LpMaximize)
 vars = LpVariable.dicts("Number of Chairs", Chairs, lowBound=0)
 # objective

--- a/examples/test2.py
+++ b/examples/test2.py
@@ -8,7 +8,7 @@
 from pulp import *
 
 # Import math functions
-from math import *
+import math
 
 # A new LP problem
 prob = LpProblem("test2", LpMaximize)
@@ -16,15 +16,15 @@ prob = LpProblem("test2", LpMaximize)
 # Parameters
 # Size of the problem
 n = 15
-k = floor(log(n) / log(2))
+k = math.floor(math.log(n) / math.log(2))
 
 # A vector of n binary variables
-x = LpVariable.matrix("x", list(range(n)), 0, 1, LpInteger)
+x = LpVariable.matrix("x", list(range(n)), lowBound=0, upBound=1, cat=LpInteger)
 
 # A vector of weights
 a = [pow(2, k + n + 1) + pow(2, k + n + 1 - j) + 1 for j in range(1, n + 1)]
 # The maximum weight
-b = 0.5 * floor(sum(a))
+b = 0.5 * math.floor(sum(a))
 
 # The total weight
 weight = lpDot(a, x)

--- a/examples/test3.py
+++ b/examples/test3.py
@@ -9,7 +9,8 @@
 # The hydro unit has an initial storage.
 
 from pulp import *
-from math import *
+import math
+from typing import cast
 
 prob = LpProblem("test3", LpMinimize)
 
@@ -36,13 +37,13 @@ xtime = list(range(tmax + 1))
 unit = list(range(units))
 # The demand
 demand = [
-    dmin + (dmax - dmin) * 0.5 + 0.5 * (dmax - dmin) * sin(4 * t * 2 * 3.1415 / tmax)
+    dmin + (dmax - dmin) * 0.5 + 0.5 * (dmax - dmin) * math.sin(4 * t * 2 * 3.1415 / tmax)
     for t in time
 ]
 # Maximum output for the thermal units
-pmax = [tpmax / units for i in unit]
+pmax = [tpmax / units for _ in unit]
 # Minimum output for the thermal units
-pmin = [tpmax / (units * 3.0) for i in unit]
+pmin = [tpmax / (units * 3.0) for _ in unit]
 # Proportional cost of the thermal units
 costs = [i + 1 for i in unit]
 # Startup cost of the thermal units.
@@ -76,7 +77,7 @@ for t in time:
         prob += u[t][i] >= d[t + 1][i] - d[t][i]
 
 # Storage for the hydro plant (must not go below 0)
-s = LpVariable.matrix("s", xtime, 0)
+s: list[LpVariable | float] = cast(list[LpVariable | float], LpVariable.matrix("s", xtime, 0))
 
 # Initial storage
 s[0] = sini
@@ -103,6 +104,7 @@ prob += ctp + cts
 # Solve the problem
 prob.solve()
 
+assert prob.objective is not None
 print("Minimum total cost:", prob.objective.value())
 
 # Print the results

--- a/examples/test4.py
+++ b/examples/test4.py
@@ -9,7 +9,7 @@
 # IIASA, WP-94-021, April 1994 (revised October 1995).
 
 from pulp import *
-from random import *
+from random import randint
 
 C = 50
 B = 500  # Resources available for the two years
@@ -20,11 +20,11 @@ N = list(range(n))
 S = list(range(s))
 
 # First year costs
-c = [randint(0, C) for i in N]
+c = [randint(0, C) for _ in N]
 # First year resources
-d = [randint(0, C) for i in N]
+d = [randint(0, C) for _ in N]
 # a=debut, b=taille
-interval = [[(randint(0, C), randint(0, C)) for i in N] for j in S]
+interval = [[(randint(0, C), randint(0, C)) for _i in N] for _j in S]
 # Final earnings
 q = [[randint(ai, ai + bi) for ai, bi in ab] for ab in interval]
 # Second year resources

--- a/examples/test5.py
+++ b/examples/test5.py
@@ -10,7 +10,7 @@
 from pulp import *
 
 # Import random number generation functions
-from random import *
+from random import randint
 
 # A new LP problem
 prob = LpProblem("test5", LpMinimize)
@@ -35,7 +35,7 @@ w = LpVariable.matrix("w", list(range(m)), 0)
 prob += lpSum(s) + lpSum(w)
 
 # Constraints
-d = [[randint(0, D) for i in range(n)] for j in range(m)]
+d = [[randint(0, D) for _i in range(n)] for _j in range(m)]
 for j in range(m):
     prob += lpDot(d[j], x) + s[j] - w[j] == lpSum(d[j]) / 2
 

--- a/pulp/__init__.py
+++ b/pulp/__init__.py
@@ -35,7 +35,7 @@ from .pulp import *
 from .apis import *
 from .utilities import *
 from .constants import *
-from .tests import pulpTestAll
+from .tests import pulpTestAll  # type: ignore
 
 __doc__ = pulp.__doc__
 __version__ = VERSION

--- a/pulp/apis/__init__.py
+++ b/pulp/apis/__init__.py
@@ -12,7 +12,7 @@ from .copt_api import *
 from .sas_api import *
 from .core import *
 
-_all_solvers = [
+_all_solvers: list[type[LpSolver]] = [
     GLPK_CMD,
     PYGLPK,
     CPLEX_CMD,
@@ -95,7 +95,7 @@ def configSolvers():
     setConfigInformation(**configdict)
 
 
-def getSolver(solver, *args, **kwargs):
+def getSolver(solver: str, *args: Any, **kwargs: Any) -> LpSolver:
     """
     Instantiates a solver from its name
 
@@ -115,7 +115,7 @@ def getSolver(solver, *args, **kwargs):
         )
 
 
-def getSolverFromDict(data):
+def getSolverFromDict(data: dict[str, Any]) -> LpSolver:
     """
     Instantiates a solver from a dictionary with its data
 
@@ -132,7 +132,7 @@ def getSolverFromDict(data):
     return getSolver(solver, **data)
 
 
-def getSolverFromJson(filename):
+def getSolverFromJson(filename: str) -> LpSolver:
     """
     Instantiates a solver from a json file with its data
 
@@ -145,7 +145,7 @@ def getSolverFromJson(filename):
     return getSolverFromDict(data)
 
 
-def listSolvers(onlyAvailable=False):
+def listSolvers(onlyAvailable: bool = False) -> list[str]:
     """
     List the names of all the existing solvers in PuLP
 
@@ -153,7 +153,7 @@ def listSolvers(onlyAvailable=False):
     :return: list of solver names
     :rtype: list
     """
-    result = []
+    result: list[str] = []
     for s in _all_solvers:
         solver = s(msg=False)
         if (not onlyAvailable) or solver.available():

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -150,12 +150,12 @@ class CPLEX_CMD(LpSolver_CMD):
     def readsol(self, filename):
         """Read a CPLEX solution file"""
         # CPLEX solution codes: http://www-eio.upc.es/lceio/manuals/cplex-11/html/overviewcplex/statuscodes.html
-        try:
-            import xml.etree.ElementTree as et
-        except ImportError:
-            import elementtree.ElementTree as et
+        import xml.etree.ElementTree as et
+
         solutionXML = et.parse(filename).getroot()
         solutionheader = solutionXML.find("header")
+        if solutionheader is None:
+            raise constants.PulpError("Failed to find header")
         statusString = solutionheader.get("solutionStatusString")
         statusValue = solutionheader.get("solutionStatusValue")
         cplexStatus = {
@@ -188,6 +188,8 @@ class CPLEX_CMD(LpSolver_CMD):
         shadowPrices = {}
         slacks = {}
         constraints = solutionXML.find("linearConstraints")
+        if constraints is None:
+            raise constants.PulpError("Failed to find linearConstraints")
         for constraint in constraints:
             name = constraint.get("name")
             slack = constraint.get("slack")
@@ -216,10 +218,8 @@ class CPLEX_CMD(LpSolver_CMD):
 
     def writesol(self, filename, vs):
         """Writes a CPLEX solution file"""
-        try:
-            import xml.etree.ElementTree as et
-        except ImportError:
-            import elementtree.ElementTree as et
+        import xml.etree.ElementTree as et
+
         root = et.Element("CPLEXSolution", version="1.2")
         attrib_head = dict()
         attrib_quality = dict()

--- a/pulp/apis/mosek_api.py
+++ b/pulp/apis/mosek_api.py
@@ -1,5 +1,6 @@
 # PuLP : Python LP Modeler
 # Version 1.4.2
+from __future__ import annotations
 
 # Copyright (c) 2002-2005, Jean-Sebastien Roy (js@jeannot.org)
 # Modifications Copyright (c) 2007- Stuart Anthony Mitchell (s.mitchell@auckland.ac.nz)
@@ -28,7 +29,10 @@ from .core import LpSolver, PulpSolverError
 from .. import constants
 import sys
 
-from typing import Optional
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pulp.pulp import LpProblem
 
 
 class MOSEK(LpSolver):
@@ -42,11 +46,11 @@ class MOSEK(LpSolver):
         env = mosek.Env()
     except ImportError:
 
-        def available(self):
+        def available(self) -> bool:
             """True if Mosek is available."""
             return False
 
-        def actualSolve(self, lp, callback=None):
+        def actualSolve(self, lp: LpProblem, callback=None):
             """Solves a well-formulated lp problem."""
             raise PulpSolverError("MOSEK : Not Available")
 
@@ -54,11 +58,11 @@ class MOSEK(LpSolver):
 
         def __init__(
             self,
-            mip=True,
-            msg=True,
-            timeLimit: Optional[float] = None,
-            options: Optional[dict] = None,
-            task_file_name="",
+            mip: bool = True,
+            msg: bool = True,
+            timeLimit: float | None = None,
+            options: dict[str, str] | None = None,
+            task_file_name: str = "",
             sol_type=mosek.soltype.bas,
         ):
             """Initializes the Mosek solver.
@@ -104,16 +108,16 @@ class MOSEK(LpSolver):
                     )
                 self.options["MSK_DPAR_MIO_MAX_TIME"] = self.timeLimit
 
-        def available(self):
+        def available(self) -> bool:
             """True if Mosek is available."""
             return True
 
-        def setOutStream(self, text):
+        def setOutStream(self, text: str):
             """Sets the log-output stream."""
             sys.stdout.write(text)
             sys.stdout.flush()
 
-        def buildSolverModel(self, lp, inf=1e20):
+        def buildSolverModel(self, lp: LpProblem, inf: float = 1e20):
             """Translate the problem into a Mosek task object."""
             self.cons = lp.constraints
             self.numcons = len(self.cons)
@@ -204,7 +208,7 @@ class MOSEK(LpSolver):
             else:
                 self.task.putobjsense(mosek.objsense.minimize)
 
-        def findSolutionValues(self, lp):
+        def findSolutionValues(self, lp: LpProblem):
             """
             Read the solution values and status from the Mosek task object. Note: Since the status
             map from mosek.solsta to LpStatus is not exact, it is recommended that one enables the
@@ -286,7 +290,7 @@ class MOSEK(LpSolver):
                         )
                     )
 
-        def actualSolve(self, lp):
+        def actualSolve(self, lp: LpProblem) -> int:
             """
             Solve a well-formulated lp problem.
             """
@@ -310,7 +314,7 @@ class MOSEK(LpSolver):
                 con.modified = False
             return lp.status
 
-        def actualResolve(self, lp, inf=1e20, **kwargs):
+        def actualResolve(self, lp: LpProblem, inf: float = 1e20, **kwargs: Any):
             """
             Modify constraints and re-solve an lp. The Mosek task object created in the first solve is used.
             """

--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -1,5 +1,6 @@
 # PuLP : Python LP Modeler
 # Version 1.4.2
+from __future__ import annotations
 
 # Copyright (c) 2002-2005, Jean-Sebastien Roy (js@jeannot.org)
 # Modifications Copyright (c) 2007- Stuart Anthony Mitchell (s.mitchell@auckland.ac.nz)
@@ -33,7 +34,10 @@ from .core import LpSolver_CMD, LpSolver, subprocess, PulpSolverError
 from .core import scip_path, fscip_path
 from .. import constants
 
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Any, cast
+
+if TYPE_CHECKING:
+    from pulp.pulp import LpProblem
 
 
 class SCIP_CMD(LpSolver_CMD):
@@ -43,17 +47,17 @@ class SCIP_CMD(LpSolver_CMD):
 
     def __init__(
         self,
-        path=None,
-        mip=True,
-        keepFiles=False,
-        msg=True,
-        options=None,
-        timeLimit=None,
-        gapRel=None,
-        gapAbs=None,
-        maxNodes=None,
-        logPath=None,
-        threads=None,
+        path: str | None = None,
+        mip: bool = True,
+        keepFiles: bool = False,
+        msg: bool = True,
+        options: list[str] | None = None,
+        timeLimit: float | None = None,
+        gapRel: float | None = None,
+        gapAbs: float | None = None,
+        maxNodes: int | None = None,
+        logPath: str | None = None,
+        threads: int | None = None,
     ):
         """
         :param bool mip: if False, assume LP even if integer variables
@@ -68,8 +72,7 @@ class SCIP_CMD(LpSolver_CMD):
         :param int threads: sets the maximum number of threads
         :param str logPath: path to the log file
         """
-        LpSolver_CMD.__init__(
-            self,
+        super().__init__(
             mip=mip,
             msg=msg,
             options=options,
@@ -109,9 +112,9 @@ class SCIP_CMD(LpSolver_CMD):
     def defaultPath(self):
         return self.executableExtension(scip_path)
 
-    def available(self):
+    def available(self) -> bool:
         """True if the solver is available"""
-        return self.executable(self.path)
+        return self.executable(self.path) is not None
 
     def actualSolve(self, lp):
         """Solve a well formulated lp problem"""
@@ -121,7 +124,7 @@ class SCIP_CMD(LpSolver_CMD):
         tmpLp, tmpSol, tmpOptions = self.create_tmp_files(lp.name, "lp", "sol", "set")
         lp.writeLP(tmpLp)
 
-        file_options: List[str] = []
+        file_options: list[str] = []
         if self.timeLimit is not None:
             file_options.append(f"limits/time={self.timeLimit}")
         if "gapRel" in self.optionsDict:
@@ -137,7 +140,7 @@ class SCIP_CMD(LpSolver_CMD):
         if not self.mip:
             warnings.warn(f"{self.name} does not allow a problem to be relaxed")
 
-        command: List[str] = []
+        command: list[str] = []
         command.append(self.path)
         command.extend(["-s", tmpOptions])
         if not self.msg:
@@ -183,7 +186,7 @@ class SCIP_CMD(LpSolver_CMD):
         return status
 
     @staticmethod
-    def readsol(filename):
+    def readsol(filename: str):
         """Read a SCIP solution file"""
         with open(filename) as f:
             # First line must contain 'solution status: <something>'
@@ -291,7 +294,7 @@ class FSCIP_CMD(LpSolver_CMD):
         """True if the solver is available"""
         return self.executable(self.path)
 
-    def actualSolve(self, lp):
+    def actualSolve(self, lp: LpProblem):
         """Solve a well formulated lp problem"""
         if not self.executable(self.path):
             raise PulpSolverError("PuLP: cannot execute " + self.path)
@@ -301,7 +304,7 @@ class FSCIP_CMD(LpSolver_CMD):
         )
         lp.writeLP(tmpLp)
 
-        file_options: List[str] = []
+        file_options: list[str] = []
         if self.timeLimit is not None:
             file_options.append(f"limits/time={self.timeLimit}")
         if "gapRel" in self.optionsDict:
@@ -313,11 +316,11 @@ class FSCIP_CMD(LpSolver_CMD):
         if not self.mip:
             warnings.warn(f"{self.name} does not allow a problem to be relaxed")
 
-        file_parameters: List[str] = []
+        file_parameters: list[str] = []
         # disable presolving in the LoadCoordinator to make sure a solution file is always written
         file_parameters.append("NoPreprocessingInLC = TRUE")
 
-        command: List[str] = []
+        command: list[str] = []
         command.append(self.path)
         command.append(tmpParams)
         command.append(tmpLp)
@@ -377,14 +380,14 @@ class FSCIP_CMD(LpSolver_CMD):
         return status
 
     @staticmethod
-    def parse_status(string: str) -> Optional[int]:
+    def parse_status(string: str) -> int | None:
         for fscip_status, pulp_status in FSCIP_CMD.FSCIP_STATUSES.items():
             if fscip_status in string:
                 return pulp_status
         return None
 
     @staticmethod
-    def parse_objective(string: str) -> Optional[float]:
+    def parse_objective(string: str) -> float | None:
         fields = string.split(":")
         if len(fields) != 2:
             return None
@@ -402,7 +405,7 @@ class FSCIP_CMD(LpSolver_CMD):
         return objective
 
     @staticmethod
-    def parse_variable(string: str) -> Optional[Tuple[str, float]]:
+    def parse_variable(string: str) -> tuple[str, float] | None:
         fields = string.split()
         if len(fields) < 2:
             return None
@@ -416,7 +419,7 @@ class FSCIP_CMD(LpSolver_CMD):
         return name, value
 
     @staticmethod
-    def readsol(filename):
+    def readsol(filename: str):
         """Read a FSCIP solution file"""
         with open(filename) as file:
             # First line must contain a solution status
@@ -472,11 +475,11 @@ class SCIP_PY(LpSolver):
 
     except ImportError:
 
-        def available(self):
+        def available(self) -> bool:
             """True if the solver is available"""
             return False
 
-        def actualSolve(self, lp):
+        def actualSolve(self, lp: LpProblem):
             """Solve a well formulated lp problem"""
             raise PulpSolverError(f"The {self.name} solver is not available")
 
@@ -484,16 +487,16 @@ class SCIP_PY(LpSolver):
 
         def __init__(
             self,
-            mip=True,
-            msg=True,
-            options=None,
-            timeLimit=None,
-            gapRel=None,
-            gapAbs=None,
-            maxNodes=None,
-            logPath=None,
-            threads=None,
-            warmStart=False,
+            mip: bool = True,
+            msg: bool = True,
+            options: list[str] | None = None,
+            timeLimit: float | None = None,
+            gapRel: float | None = None,
+            gapAbs: float | None = None,
+            maxNodes: int | None = None,
+            logPath: float | None = None,
+            threads: int | None = None,
+            warmStart: bool = False,
         ):
             """
             :param bool mip: if False, assume LP even if integer variables
@@ -520,7 +523,7 @@ class SCIP_PY(LpSolver):
                 warmStart=warmStart,
             )
 
-        def findSolutionValues(self, lp):
+        def findSolutionValues(self, lp: LpProblem):
             lp.resolveOK = True
 
             solutionStatus = lp.solverModel.getStatus()
@@ -581,16 +584,16 @@ class SCIP_PY(LpSolver):
 
             return status
 
-        def available(self):
+        def available(self) -> bool:
             """True if the solver is available"""
             # if pyscipopt can be installed (and therefore imported) it has access to scip
             return True
 
-        def callSolver(self, lp):
+        def callSolver(self, lp: LpProblem):
             """Solves the problem with scip"""
             lp.solverModel.optimize()
 
-        def buildSolverModel(self, lp):
+        def buildSolverModel(self, lp: LpProblem):
             """
             Takes the pulp lp model and translates it into a scip model
             """
@@ -654,7 +657,7 @@ class SCIP_PY(LpSolver):
             ##################################################
             # add constraints
             ##################################################
-            sense_to_operator = {
+            sense_to_operator: dict[int, Callable[[Any, Any], bool]] = {
                 constants.LpConstraintLE: operator.le,
                 constants.LpConstraintGE: operator.ge,
                 constants.LpConstraintEQ: operator.eq,
@@ -682,7 +685,7 @@ class SCIP_PY(LpSolver):
                         lp.solverModel.setSolVal(s, var.solverVar, var.varValue)
                 lp.solverModel.addSol(s)
 
-        def actualSolve(self, lp):
+        def actualSolve(self, lp: LpProblem):
             """
             Solve a well formulated lp problem
 
@@ -698,7 +701,7 @@ class SCIP_PY(LpSolver):
                 constraint.modified = False
             return solutionStatus
 
-        def actualResolve(self, lp):
+        def actualResolve(self, lp: LpProblem):
             """
             Solve a well formulated lp problem
 

--- a/pulp/mps_lp.py
+++ b/pulp/mps_lp.py
@@ -4,9 +4,15 @@
 
 """
 
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING, Any
 
 from . import constants as const
+
+if TYPE_CHECKING:
+    from pulp.pulp import LpProblem, LpVariable, LpAffineExpression, LptNumber
 
 CORE_FILE_ROW_MODE = "ROWS"
 CORE_FILE_COL_MODE = "COLUMNS"
@@ -20,15 +26,62 @@ CORE_FILE_RHS_MODE_NO_NAME = "RHS_NO_NAME"
 
 ROW_MODE_OBJ = "N"
 
-BOUNDS_EQUIV = dict(LO="lowBound", UP="upBound")
-
 ROW_EQUIV = {v: k for k, v in const.LpConstraintTypeToMps.items()}
 COL_EQUIV = {1: "Integer", 0: "Continuous"}
-ROW_DEFAULT = dict(pi=None, constant=0)
-COL_DEFAULT = dict(lowBound=0, upBound=None, varValue=None, dj=None)
+
+from dataclasses import dataclass
 
 
-def readMPS(path, sense, dropConsNames=False):
+@dataclass
+class MPSParameters:
+    name: str
+    sense: int
+    status: int
+    sol_status: int
+
+
+@dataclass
+class MPSCoefficient:
+    name: str
+    value: float
+
+
+@dataclass
+class MPSObjective:
+    name: str | None
+    coefficients: list[MPSCoefficient]
+
+
+@dataclass
+class MPSVariable:
+    name: str
+    cat: str
+    lowBound: float | None = 0
+    upBound: float | None = None
+    varValue: float | None = None
+    dj: float | None = None
+
+
+@dataclass
+class MPSConstraint:
+    name: str | None
+    sense: int
+    coefficients: list[MPSCoefficient]
+    pi: float | None = None
+    constant: float = 0
+
+
+@dataclass
+class MPS:
+    parameters: MPSParameters
+    objective: MPSObjective
+    variables: list[MPSVariable]
+    constraints: list[MPSConstraint]
+    sos1: list[Any]
+    sos2: list[Any]
+
+
+def readMPS(path: str, sense: int, dropConsNames: bool = False) -> MPS:
     """
     adapted from Julian Märte (https://github.com/pchtsp/pysmps)
     returns a dictionary with the contents of the model.
@@ -41,16 +94,16 @@ def readMPS(path, sense, dropConsNames=False):
     """
 
     mode = ""
-    parameters = dict(name="", sense=sense, status=0, sol_status=0)
-    variable_info = {}
-    constraints = {}
-    objective = dict(name="", coefficients=[])
-    sos1 = []
-    sos2 = []
+    parameters = MPSParameters(name="", sense=sense, status=0, sol_status=0)
+    variable_info: dict[str, MPSVariable] = {}
+    constraints: dict[str, MPSConstraint] = {}
+    objective = MPSObjective(name="", coefficients=[])
+    sos1: list[Any] = []
+    sos2: list[Any] = []
     # TODO: maybe take out rhs_names and bnd_names? not sure if they're useful
-    rhs_names = []
-    bnd_names = []
-    integral_marker = False
+    rhs_names: list[str] = []
+    bnd_names: list[str] = []
+    integral_marker: bool = False
 
     with open(path) as reader:
         for line in reader:
@@ -64,9 +117,9 @@ def readMPS(path, sense, dropConsNames=False):
                 continue
             if line[0] == "NAME":
                 if len(line) > 1:
-                    parameters["name"] = line[1]
+                    parameters.name = line[1]
                 else:
-                    parameters["name"] = ""
+                    parameters.name = ""
                 continue
 
             # here we get the mode
@@ -90,13 +143,10 @@ def readMPS(path, sense, dropConsNames=False):
                 row_type = line[0]
                 row_name = line[1]
                 if row_type == ROW_MODE_OBJ:
-                    objective["name"] = row_name
+                    objective.name = row_name
                 else:
-                    constraints[row_name] = dict(
-                        sense=ROW_EQUIV[row_type],
-                        name=row_name,
-                        coefficients=[],
-                        **ROW_DEFAULT,
+                    constraints[row_name] = MPSConstraint(
+                        name=row_name, sense=ROW_EQUIV[row_type], coefficients=[]
                     )
             elif mode == CORE_FILE_COL_MODE:
                 var_name = line[0]
@@ -107,25 +157,25 @@ def readMPS(path, sense, dropConsNames=False):
                         integral_marker = False
                     continue
                 if var_name not in variable_info:
-                    variable_info[var_name] = dict(
-                        cat=COL_EQUIV[integral_marker], name=var_name, **COL_DEFAULT
+                    variable_info[var_name] = MPSVariable(
+                        cat=COL_EQUIV[integral_marker], name=var_name
                     )
                 j = 1
                 while j < len(line) - 1:
-                    if line[j] == objective["name"]:
+                    if line[j] == objective.name:
                         # we store the variable objective coefficient
-                        objective["coefficients"].append(
-                            dict(name=var_name, value=float(line[j + 1]))
+                        objective.coefficients.append(
+                            MPSCoefficient(name=var_name, value=float(line[j + 1]))
                         )
                     else:
                         # we store the variable coefficient
-                        constraints[line[j]]["coefficients"].append(
-                            dict(name=var_name, value=float(line[j + 1]))
+                        constraints[line[j]].coefficients.append(
+                            MPSCoefficient(name=var_name, value=float(line[j + 1]))
                         )
                     j = j + 2
             elif mode == CORE_FILE_RHS_MODE_NAME_GIVEN:
                 if line[0] != rhs_names[-1]:
-                    raise Exception(
+                    raise const.PulpError(
                         "Other RHS name was given even though name was set after RHS tag."
                     )
                 readMPSSetRhs(line, constraints)
@@ -135,7 +185,7 @@ def readMPS(path, sense, dropConsNames=False):
                     rhs_names.append(line[0])
             elif mode == CORE_FILE_BOUNDS_MODE_NAME_GIVEN:
                 if line[1] != bnd_names[-1]:
-                    raise Exception(
+                    raise const.PulpError(
                         "Other BOUNDS name was given even though name was set after BOUNDS tag."
                     )
                 readMPSSetBounds(line, variable_info)
@@ -143,81 +193,84 @@ def readMPS(path, sense, dropConsNames=False):
                 readMPSSetBounds(line, variable_info)
                 if line[1] not in bnd_names:
                     bnd_names.append(line[1])
-    constraints = list(constraints.values())
+    constraints_list = list(constraints.values())
     if dropConsNames:
-        for c in constraints:
-            c["name"] = None
-        objective["name"] = None
-    variable_info = list(variable_info.values())
-    return dict(
+        for c in constraints_list:
+            c.name = None
+        objective.name = None
+    variable_info_list = list(variable_info.values())
+    return MPS(
         parameters=parameters,
         objective=objective,
-        variables=variable_info,
-        constraints=constraints,
+        variables=variable_info_list,
+        constraints=constraints_list,
         sos1=sos1,
         sos2=sos2,
     )
 
 
-def readMPSSetBounds(line, variable_dict):
+def readMPSSetBounds(line: list[str], variable_dict: dict[str, MPSVariable]):
     bound = line[0]
     var_name = line[2]
 
-    def set_one_bound(bound_type, value):
-        variable_dict[var_name][BOUNDS_EQUIV[bound_type]] = value
-
-    def set_both_bounds(value_low, value_up):
-        set_one_bound("LO", value_low)
-        set_one_bound("UP", value_up)
-
     if bound == "FR":
-        set_both_bounds(None, None)
-        return
+        variable_dict[var_name].lowBound = None
+        variable_dict[var_name].upBound = None
     elif bound == "BV":
-        set_both_bounds(0, 1)
-        return
+        variable_dict[var_name].lowBound = 0
+        variable_dict[var_name].upBound = 1
     elif bound == "PL":
-        # bounds equal to defaults
-        return
+        variable_dict[var_name].lowBound = 0
+        variable_dict[var_name].upBound = None
     elif bound == "MI":
-        set_one_bound("LO", None)
-        return
+        variable_dict[var_name].lowBound = None
+        variable_dict[var_name].upBound = 0
+    else:
+        value = float(line[3])
+        if bound == "LO":
+            variable_dict[var_name].lowBound = value
+        elif bound == "UP":
+            variable_dict[var_name].upBound = value
+        elif bound == "FX":
+            variable_dict[var_name].lowBound = value
+            variable_dict[var_name].upBound = value
+        else:
+            raise const.PulpError(f"Unknown bound {bound}")
 
-    value = float(line[3])
-    if bound in ["LO", "UP"]:
-        set_one_bound(bound, value)
-    elif bound == "FX":
-        set_both_bounds(value, value)
-    return
 
-
-def readMPSSetRhs(line, constraintsDict):
-    constraintsDict[line[1]]["constant"] = -float(line[2])
+def readMPSSetRhs(line: list[str], constraintsDict: dict[str, MPSConstraint]):
+    constraintsDict[line[1]].constant = -float(line[2])
     if len(line) == 5:  # read fields 5, 6
-        constraintsDict[line[3]]["constant"] = -float(line[4])
-    return
+        constraintsDict[line[3]].constant = -float(line[4])
 
 
 def writeMPS(
-    LpProblem, filename, mpsSense=0, rename=0, mip=1, with_objsense: bool = False
+    lp: LpProblem,
+    filename: str,
+    mpsSense: int = 0,
+    rename: bool = False,
+    mip: bool = True,
+    with_objsense: bool = False,
 ):
-    wasNone, dummyVar = LpProblem.fixObjective()
+    wasNone, dummyVar = lp.fixObjective()
     if mpsSense == 0:
-        mpsSense = LpProblem.sense
-    cobj = LpProblem.objective
-    if mpsSense != LpProblem.sense:
+        mpsSense = lp.sense
+    cobj = lp.objective
+    if cobj is None:
+        raise ValueError("objective is None")
+    if mpsSense != lp.sense:
         n = cobj.name
         cobj = -cobj
         cobj.name = n
     if rename:
-        constrNames, varNames, cobj.name = LpProblem.normalisedNames()
+        constrNames, varNames, cobj.name = lp.normalisedNames()
         # No need to call self.variables() again, we have just filled self._variables:
-        vs = LpProblem._variables
+        vs = lp._variables  # type: ignore
     else:
-        vs = LpProblem.variables()
+        vs = lp.variables()
         varNames = {v.name: v.name for v in vs}
-        constrNames = {c: c for c in LpProblem.constraints}
-    model_name = LpProblem.name
+        constrNames = {c: c for c in lp.constraints}
+    model_name = lp.name
     if rename:
         model_name = "MODEL"
     objName = cobj.name
@@ -227,18 +280,18 @@ def writeMPS(
     # constraints
     row_lines = [
         " " + const.LpConstraintTypeToMps[c.sense] + "  " + constrNames[k] + "\n"
-        for k, c in LpProblem.constraints.items()
+        for k, c in lp.constraints.items()
     ]
     # Creation of a dict of dict:
     # coefs[variable_name][constraint_name] = coefficient
-    coefs = {varNames[v.name]: {} for v in vs}
-    for k, c in LpProblem.constraints.items():
+    coefs: dict[str, dict[str, LptNumber]] = {varNames[v.name]: {} for v in vs}
+    for k, c in lp.constraints.items():
         k = constrNames[k]
         for v, value in c.items():
             coefs[varNames[v.name]][k] = value
 
     # matrix
-    columns_lines = []
+    columns_lines: list[str] = []
     for v in vs:
         name = varNames[v.name]
         columns_lines.extend(
@@ -249,10 +302,10 @@ def writeMPS(
     rhs_lines = [
         "    RHS       %-8s  % .12e\n"
         % (constrNames[k], -c.constant if c.constant != 0 else 0)
-        for k, c in LpProblem.constraints.items()
+        for k, c in lp.constraints.items()
     ]
     # bounds
-    bound_lines = []
+    bound_lines: list[str] = []
     for v in vs:
         bound_lines.extend(writeMPSBoundLines(varNames[v.name], v, mip))
 
@@ -273,16 +326,23 @@ def writeMPS(
         f.write("BOUNDS\n")
         f.write("".join(bound_lines))
         f.write("ENDATA\n")
-    LpProblem.restoreObjective(wasNone, dummyVar)
+    lp.restoreObjective(wasNone, dummyVar)
     # returns the variables, in writing order
-    if rename == 0:
+    if not rename:
         return vs
     else:
         return vs, varNames, constrNames, cobj.name
 
 
-def writeMPSColumnLines(cv, variable, mip, name, cobj, objName):
-    columns_lines = []
+def writeMPSColumnLines(
+    cv: dict[str, LptNumber],
+    variable: LpVariable,
+    mip: bool,
+    name: str,
+    cobj: LpAffineExpression,
+    objName: str,
+) -> list[str]:
+    columns_lines: list[str] = []
     if mip and variable.cat == const.LpInteger:
         columns_lines.append("    MARK      'MARKER'                 'INTORG'\n")
     # Most of the work is done here
@@ -299,7 +359,7 @@ def writeMPSColumnLines(cv, variable, mip, name, cobj, objName):
     return columns_lines
 
 
-def writeMPSBoundLines(name, variable, mip):
+def writeMPSBoundLines(name: str, variable: LpVariable, mip: bool) -> list[str]:
     if variable.lowBound is not None and variable.lowBound == variable.upBound:
         return [" FX BND       %-8s  % .12e\n" % (name, variable.lowBound)]
     elif (
@@ -309,7 +369,7 @@ def writeMPSBoundLines(name, variable, mip):
         and variable.cat == const.LpInteger
     ):
         return [" BV BND       %-8s\n" % name]
-    bound_lines = []
+    bound_lines: list[str] = []
     if variable.lowBound is not None:
         # In MPS files, variables with no bounds (i.e. >= 0)
         # are assumed BV by COIN and CPLEX.
@@ -330,29 +390,35 @@ def writeMPSBoundLines(name, variable, mip):
     return bound_lines
 
 
-def writeLP(LpProblem, filename, writeSOS=1, mip=1, max_length=100):
+def writeLP(
+    lp: LpProblem,
+    filename: str,
+    writeSOS: bool = True,
+    mip: bool = True,
+    max_length: int = 100,
+):
+    if lp.objective is None:
+        raise ValueError("objective is None")
     f = open(filename, "w")
-    f.write("\\* " + LpProblem.name + " *\\\n")
-    if LpProblem.sense == 1:
+    f.write("\\* " + lp.name + " *\\\n")
+    if lp.sense == 1:
         f.write("Minimize\n")
     else:
         f.write("Maximize\n")
-    wasNone, objectiveDummyVar = LpProblem.fixObjective()
-    objName = LpProblem.objective.name
+    wasNone, objectiveDummyVar = lp.fixObjective()
+    objName = lp.objective.name
     if not objName:
         objName = "OBJ"
-    f.write(
-        LpProblem.objective.asCplexLpAffineExpression(objName, include_constant=False)
-    )
+    f.write(lp.objective.asCplexLpAffineExpression(objName, include_constant=False))
     f.write("Subject To\n")
-    ks = list(LpProblem.constraints.keys())
+    ks = list(lp.constraints.keys())
     ks.sort()
     dummyWritten = False
     for k in ks:
-        constraint = LpProblem.constraints[k]
+        constraint = lp.constraints[k]
         if not list(constraint.keys()):
             # empty constraint add the dummyVar
-            dummyVar = LpProblem.get_dummyVar()
+            dummyVar = lp.get_dummyVar()
             constraint += dummyVar
             # set this dummyvar to zero so infeasible problems are not made feasible
             if not dummyWritten:
@@ -360,10 +426,10 @@ def writeLP(LpProblem, filename, writeSOS=1, mip=1, max_length=100):
                 dummyWritten = True
         f.write(constraint.asCplexLpConstraint(k))
     # check if any names are longer than 100 characters
-    LpProblem.checkLengthVars(max_length)
-    vs = LpProblem.variables()
+    lp.checkLengthVars(max_length)
+    vs = lp.variables()
     # check for repeated names
-    LpProblem.checkDuplicateVars()
+    lp.checkDuplicateVars()
     # Bounds on non-"positive" variables
     # Note: XPRESS and CPLEX do not interpret integer variables without
     # explicit bounds
@@ -393,19 +459,19 @@ def writeLP(LpProblem, filename, writeSOS=1, mip=1, max_length=100):
             for v in vg:
                 f.write(f"{v.name}\n")
     # Special Ordered Sets
-    if writeSOS and (LpProblem.sos1 or LpProblem.sos2):
+    if writeSOS and (lp.sos1 or lp.sos2):
         f.write("SOS\n")
-        if LpProblem.sos1:
-            for sos in LpProblem.sos1.values():
+        if lp.sos1:
+            for sos in lp.sos1.values():
                 f.write("S1:: \n")
                 for v, val in sos.items():
                     f.write(f" {v.name}: {val:.12g}\n")
-        if LpProblem.sos2:
-            for sos in LpProblem.sos2.values():
+        if lp.sos2:
+            for sos in lp.sos2.values():
                 f.write("S2:: \n")
                 for v, val in sos.items():
                     f.write(f" {v.name}: {val:.12g}\n")
     f.write("End\n")
     f.close()
-    LpProblem.restoreObjective(wasNone, objectiveDummyVar)
+    lp.restoreObjective(wasNone, objectiveDummyVar)
     return vs

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -137,7 +137,6 @@ from typing import (
     TypeAlias,
     overload,
     Union,
-    TypedDict,
     cast,
 )
 
@@ -177,19 +176,6 @@ LptVars: TypeAlias = "LpVariable"  # , "LpConstraintVar"]
 T = TypeVar("T")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
-
-
-class LpConstraintCoefficientsDict(TypedDict):
-    name: str | None
-    value: LptNumber
-
-
-class LpConstraintDict(TypedDict):
-    sense: int
-    pi: float | None
-    constant: LptNumber
-    name: str | None
-    coefficients: list[LpConstraintCoefficientsDict]
 
 
 # To remove illegal characters from the names

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -126,127 +126,79 @@ References
 from collections import Counter
 import warnings
 import math
-from time import time
-from typing import Any, Literal, TYPE_CHECKING
+from time import time, monotonic as clock
+from typing import (
+    Any,
+    Literal,
+    TYPE_CHECKING,
+    TypeVar,
+    Sequence,
+    Callable,
+    TypeAlias,
+    overload,
+    Union,
+    TypedDict,
+    cast,
+)
 
 from .apis import LpSolverDefault
-from .apis.core import clock
 from .utilities import value
 from . import constants as const
 from . import mps_lp as mpslp
 
 from collections.abc import Iterable
 import logging
+import dataclasses
+import dacite
 
 log = logging.getLogger(__name__)
 
-try:
-    import ujson as json
-except ImportError:
+if TYPE_CHECKING:
     import json
+else:
+    try:
+        import ujson as json
+    except ImportError:
+        import json
 
 import re
 
 if TYPE_CHECKING:
     from pulp.apis import LpSolver
+    import itertools
+
+LptNumber: TypeAlias = int | float
+LptItem: TypeAlias = Union[LptNumber, "LpVariable"]
+LptExpr: TypeAlias = Union[LptItem, "LpAffineExpression"]
+LptConstExpr: TypeAlias = Union[LptNumber, "LpAffineExpression"]
+LptExprConstraint: TypeAlias = Union[LptExpr, "LpConstraint"]
+LptVars: TypeAlias = "LpVariable"  # , "LpConstraintVar"]
+
+T = TypeVar("T")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
 
 
-class LpElement:
-    """Base class for LpVariable and LpConstraintVar"""
-
-    # To remove illegal characters from the names
-    illegal_chars = "-+[] ->/"
-    expression = re.compile(f"[{re.escape(illegal_chars)}]")
-    trans = str.maketrans(illegal_chars, "________")
-
-    def setName(self, name: str | None):
-        if name:
-            if self.expression.match(name):
-                warnings.warn(
-                    "The name {} has illegal characters that will be replaced by _".format(
-                        name
-                    )
-                )
-            self.__name = str(name).translate(self.trans)
-        else:
-            self.__name = None
-
-    def getName(self) -> str | None:
-        return self.__name
-
-    name = property(fget=getName, fset=setName)
-
-    def __init__(self, name: str | None):
-        self.name = name
-        # self.hash MUST be different for each variable
-        # else dict() will call the comparison operators that are overloaded
-        self.hash = id(self)
-        self.modified = True
-
-    def __hash__(self):
-        return self.hash
-
-    def __str__(self):
-        return self.name
-
-    def __repr__(self):
-        return self.name
-
-    def __neg__(self) -> LpAffineExpression:
-        return -LpAffineExpression(self)
-
-    def __pos__(self):
-        return self
-
-    def __bool__(self) -> bool:
-        return True
-
-    def __add__(self, other: Any) -> LpAffineExpression:
-        return LpAffineExpression(self) + other
-
-    def __radd__(self, other: Any) -> LpAffineExpression:
-        return LpAffineExpression(self) + other
-
-    def __sub__(self, other: Any) -> LpAffineExpression:
-        return LpAffineExpression(self) - other
-
-    def __rsub__(self, other: Any) -> LpAffineExpression:
-        return other - LpAffineExpression(self)
-
-    def __mul__(self, other: Any) -> LpAffineExpression:
-        return LpAffineExpression(self) * other
-
-    def __rmul__(self, other: Any) -> LpAffineExpression:
-        return LpAffineExpression(self) * other
-
-    def __div__(self, other: Any) -> LpAffineExpression:
-        return LpAffineExpression(self) / other
-
-    def __rdiv__(self, other: Any):
-        raise TypeError("Expressions cannot be divided by a variable")
-
-    def __le__(self, other: Any) -> LpConstraint:
-        return LpAffineExpression(self) <= other
-
-    def __ge__(self, other: Any) -> LpConstraint:
-        return LpAffineExpression(self) >= other
-
-    def __eq__(self, other: Any) -> LpConstraint:  # type: ignore
-        return LpAffineExpression(self) == other
-
-    def __ne__(self, other: Any) -> bool:
-        if isinstance(other, LpVariable):
-            return self.name is not other.name
-        elif isinstance(other, (LpAffineExpression, LpConstraint)):
-            if other.isAtomic():
-                return self is not other.atom()
-            else:
-                return True
-        else:
-            return True
+class LpConstraintCoefficientsDict(TypedDict):
+    name: str | None
+    value: LptNumber
 
 
-class LpVariable(LpElement):
+class LpConstraintDict(TypedDict):
+    sense: int
+    pi: float | None
+    constant: LptNumber
+    name: str | None
+    coefficients: list[LpConstraintCoefficientsDict]
+
+
+# To remove illegal characters from the names
+NAME_ILLEGAL_CHARS = "-+[] ->/"
+NAME_EXPRESSION = re.compile(f"[{re.escape(NAME_ILLEGAL_CHARS)}]")
+NAME_TRANS = str.maketrans(NAME_ILLEGAL_CHARS, "________")
+
+
+class LpVariable:
     """
     This class models an LP Variable with the specified associated parameters
 
@@ -264,17 +216,21 @@ class LpVariable(LpElement):
     def __init__(
         self,
         name: str,
-        lowBound: int | float | None = None,
-        upBound: int | float | None = None,
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
         cat: str = const.LpContinuous,
-        e: None = None,
+        e: LpAffineExpression | None = None,
     ):
-        super().__init__(name)
+        # self.hash MUST be different for each variable
+        # else dict() will call the comparison operators that are overloaded
+        self.hash = id(self)
+        self.modified: bool = True
+        self.name = name
         self._lowbound_original = self.lowBound = lowBound
         self._upbound_original = self.upBound = upBound
         self.cat = cat
-        self.varValue = None
-        self.dj = None
+        self.varValue: float | None = None
+        self.dj: float | None = None
         if cat == const.LpBinary:
             self._lowbound_original = self.lowBound = 0
             self._upbound_original = self.upBound = 1
@@ -284,14 +240,32 @@ class LpVariable(LpElement):
         if e is not None:
             self.add_expression(e)
 
-    def toDict(self):
+    @property
+    def name(self) -> str:
+        return self.__name
+
+    @name.setter
+    def name(self, name: str):
+        if NAME_EXPRESSION.match(name):
+            warnings.warn(
+                f"The name {name} has illegal characters that will be replaced by _"
+            )
+        self.__name = name.translate(NAME_TRANS)
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return self.name
+
+    def toDataclass(self) -> mpslp.MPSVariable:
         """
         Exports a variable into a dictionary with its relevant information
 
         :return: a dictionary with the variable information
         :rtype: dict
         """
-        return dict(
+        return mpslp.MPSVariable(
             lowBound=self.lowBound,
             upBound=self.upBound,
             cat=self.cat,
@@ -300,10 +274,8 @@ class LpVariable(LpElement):
             name=self.name,
         )
 
-    to_dict = toDict
-
     @classmethod
-    def fromDict(cls, dj=None, varValue=None, **kwargs: Any):
+    def fromDataclass(cls, mps: mpslp.MPSVariable):
         """
         Initializes a variable object from information that comes from a dictionary (kwargs)
 
@@ -313,31 +285,81 @@ class LpVariable(LpElement):
         :return: a :py:class:`LpVariable`
         :rtype: :LpVariable
         """
-        var = cls(**kwargs)
-        var.dj = dj
-        var.varValue = varValue
+        var = cls(
+            name=mps.name, lowBound=mps.lowBound, upBound=mps.upBound, cat=mps.cat
+        )
+        var.dj = mps.dj
+        var.varValue = mps.varValue
         return var
 
-    from_dict = fromDict
-
-    def add_expression(self, e):
+    def add_expression(self, e: LpAffineExpression):
         self.expression = e
         self.addVariableToConstraints(e)
+
+    @overload
+    @classmethod
+    def matrix(
+        cls,
+        name: str,
+        indices: list[Any],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
+        cat: str = const.LpContinuous,
+        indexStart: list[str] = [],
+    ) -> list[LpVariable]: ...
+
+    @overload
+    @classmethod
+    def matrix(
+        cls,
+        name: str,
+        indices: tuple[Iterable[Any]],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
+        cat: str = const.LpContinuous,
+        indexStart: list[str] = [],
+    ) -> list[LpVariable]: ...
+
+    @overload
+    @classmethod
+    def matrix(
+        cls,
+        name: str,
+        indices: tuple[Iterable[Any], Iterable[Any]],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
+        cat: str = const.LpContinuous,
+        indexStart: list[str] = [],
+    ) -> list[list[LpVariable]]: ...
+
+    @overload
+    @classmethod
+    def matrix(
+        cls,
+        name: str,
+        indices: tuple[Iterable[Any], Iterable[Any], Iterable[Any]],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
+        cat: str = const.LpContinuous,
+        indexStart: list[str] = [],
+    ) -> list[list[list[LpVariable]]]: ...
 
     @classmethod
     def matrix(
         cls,
         name: str,
-        indices=None,
-        lowBound: int | float | None = None,
-        upBound: int | float | None = None,
+        indices: list[Any] | tuple[Iterable[Any], ...],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
         cat: str = const.LpContinuous,
-        indexStart=[],
-    ):
+        indexStart: list[Any] = [],
+    ) -> list[Any]:
         if not isinstance(indices, tuple):
             indices = (indices,)
         if "%" not in name:
             name += "_%s" * len(indices)
+
+        indices = cast(tuple[Iterable[Any], ...], indices)
 
         index = indices[0]
         indices = indices[1:]
@@ -354,16 +376,64 @@ class LpVariable(LpElement):
                 for i in index
             ]
 
+    @overload
     @classmethod
     def dicts(
         cls,
         name: str,
-        indices=None,
-        lowBound: int | float | None = None,
-        upBound: int | float | None = None,
+        indices: list[T] | itertools.product[T],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
         cat: str = const.LpContinuous,
-        indexStart=[],
-    ):
+        indexStart: list[Any] = [],
+    ) -> dict[T, LpVariable]: ...
+
+    @overload
+    @classmethod
+    def dicts(
+        cls,
+        name: str,
+        indices: tuple[Iterable[T]],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
+        cat: str = const.LpContinuous,
+        indexStart: list[Any] = [],
+    ) -> dict[T, LpVariable]: ...
+
+    @overload
+    @classmethod
+    def dicts(
+        cls,
+        name: str,
+        indices: tuple[Iterable[T], Iterable[T2]],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
+        cat: str = const.LpContinuous,
+        indexStart: list[Any] = [],
+    ) -> dict[T, dict[T2, LpVariable]]: ...
+
+    @overload
+    @classmethod
+    def dicts(
+        cls,
+        name: str,
+        indices: tuple[Iterable[T], Iterable[T2], Iterable[T3]],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
+        cat: str = const.LpContinuous,
+        indexStart: list[Any] = [],
+    ) -> dict[T, dict[T2, dict[T3, LpVariable]]]: ...
+
+    @classmethod
+    def dicts(
+        cls,
+        name: str,
+        indices: Iterable[T] | tuple[Iterable[T], ...],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
+        cat: str = const.LpContinuous,
+        indexStart: list[Any] = [],
+    ) -> dict[T, Any]:
         """
         This function creates a dictionary of :py:class:`LpVariable` with the specified associated parameters.
 
@@ -385,9 +455,11 @@ class LpVariable(LpElement):
         if "%" not in name:
             name += "_%s" * len(indices)
 
+        indices = cast(tuple[Iterable[T], ...], indices)
+
         index = indices[0]
         indices = indices[1:]
-        d = {}
+        d: dict[T, Any] = {}
         if len(indices) == 0:
             for i in index:
                 d[i] = LpVariable(
@@ -395,24 +467,48 @@ class LpVariable(LpElement):
                 )
         else:
             for i in index:
-                d[i] = LpVariable.dicts(
+                d[i] = cls.dicts(
                     name, indices, lowBound, upBound, cat, indexStart + [i]
                 )
         return d
+
+    @overload
+    @classmethod
+    def dict(
+        cls,
+        name: str,
+        indices: list[T],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
+        cat: str = const.LpContinuous,
+    ) -> dict[T, LpVariable]: ...
+
+    @overload
+    @classmethod
+    def dict(
+        cls,
+        name: str,
+        indices: tuple[Iterable[T], ...],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
+        cat: str = const.LpContinuous,
+    ) -> dict[tuple[T, ...], LpVariable]: ...
 
     @classmethod
     def dict(
         cls,
         name: str,
-        indices,
-        lowBound: int | float | None = None,
-        upBound: int | float | None = None,
+        indices: list[T] | tuple[Iterable[T], ...],
+        lowBound: LptNumber | None = None,
+        upBound: LptNumber | None = None,
         cat: str = const.LpContinuous,
-    ) -> dict[tuple, LpVariable]:
+    ) -> dict[Any, LpVariable]:
         if not isinstance(indices, tuple):
             indices = (indices,)
         if "%" not in name:
             name += "_%s" * len(indices)
+
+        indices = cast(tuple[Iterable[T], ...], indices)
 
         lists = indices
 
@@ -421,7 +517,7 @@ class LpVariable(LpElement):
             res = []
             while len(lists):
                 first = lists[-1]
-                nres = []
+                nres: list[list[T]] = []
                 if res:
                     if first:
                         for f in first:
@@ -438,18 +534,18 @@ class LpVariable(LpElement):
         else:
             return {}
 
-        d: dict[tuple, LpVariable] = {}
+        d: dict[Any, LpVariable] = {}
         for i in index:
             d[i] = cls(name % i, lowBound, upBound, cat)
         return d
 
-    def getLb(self) -> float | int | None:
+    def getLb(self) -> LptNumber | None:
         return self.lowBound
 
-    def getUb(self) -> float | int | None:
+    def getUb(self) -> LptNumber | None:
         return self.upBound
 
-    def bounds(self, low: float | int | None, up: float | int | None):
+    def bounds(self, low: LptNumber | None, up: LptNumber | None):
         self.lowBound = low
         self.upBound = up
         self.modified = True
@@ -457,7 +553,7 @@ class LpVariable(LpElement):
     def positive(self):
         self.bounds(0, None)
 
-    def value(self) -> float | int | None:
+    def value(self) -> LptNumber | None:
         return self.varValue
 
     def round(self, epsInt: float = 1e-5, eps: float = 1e-7):
@@ -480,7 +576,7 @@ class LpVariable(LpElement):
             ):
                 self.varValue = round(self.varValue)
 
-    def roundedValue(self, eps: float = 1e-5):
+    def roundedValue(self, eps: float = 1e-5) -> float | None:
         if (
             self.cat == const.LpInteger
             and self.varValue is not None
@@ -490,7 +586,7 @@ class LpVariable(LpElement):
         else:
             return self.varValue
 
-    def valueOrDefault(self):
+    def valueOrDefault(self) -> LptNumber:
         if self.varValue is not None:
             return self.varValue
         elif self.lowBound is not None:
@@ -515,7 +611,7 @@ class LpVariable(LpElement):
         else:
             return 0
 
-    def valid(self, eps: float | int) -> bool:
+    def valid(self, eps: LptNumber) -> bool:
         if self.name == "__dummy" and self.varValue is None:
             return True
         if self.varValue is None:
@@ -564,8 +660,6 @@ class LpVariable(LpElement):
         return self.lowBound == 0 and self.upBound is None
 
     def asCplexLpVariable(self) -> str:
-        if self.name is None:
-            raise ValueError("name is None")
         if self.isFree():
             return self.name + " free"
         if self.isConstant():
@@ -588,28 +682,15 @@ class LpVariable(LpElement):
             name, include_constant
         )
 
-    def __ne__(self, other: Any) -> bool:
-        if isinstance(other, LpElement):
-            return self.name is not other.name
-        elif isinstance(other, (LpAffineExpression, LpConstraint)):
-            if other.isAtomic():
-                return self is not other.atom()
-            else:
-                return True
-        else:
-            return True
-
-    def __bool__(self) -> bool:
-        return bool(self.roundedValue())
-
-    def addVariableToConstraints(self, e):
+    def addVariableToConstraints(self, e: LpAffineExpression):
         """adds a variable to the constraints indicated by
         the LpConstraintVars in e
         """
         for constraint, coeff in e.items():
+            assert isinstance(constraint, LpConstraintVar)
             constraint.addVariable(self, coeff)
 
-    def setInitialValue(self, val: float | int, check: bool = True):
+    def setInitialValue(self, val: float, check: bool = True):
         """
         sets the initial value of the variable to `val`
         May be used for warmStart a solver, if supported by the solver
@@ -621,7 +702,7 @@ class LpVariable(LpElement):
         """
         lb = self.lowBound
         ub = self.upBound
-        config = [
+        config: list[tuple[str, str, float | int | None, Callable[[float], bool]]] = [
             ("smaller", "lowBound", lb, lambda x: val < x),
             ("greater", "upBound", ub, lambda x: val > x),
         ]
@@ -657,8 +738,63 @@ class LpVariable(LpElement):
     def unfixValue(self):
         self.bounds(self._lowbound_original, self._upbound_original)
 
+    def __hash__(self):
+        return self.hash
 
-class LpAffineExpression(dict[LpVariable, float]):
+    def __neg__(self) -> LpAffineExpression:
+        return -LpAffineExpression(self)
+
+    def __pos__(self):
+        return self
+
+    def __bool__(self) -> bool:
+        return bool(self.roundedValue())
+
+    def __add__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) + other
+
+    def __radd__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) + other
+
+    def __sub__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) - other
+
+    def __rsub__(self, other: Any) -> LpAffineExpression:
+        return other - LpAffineExpression(self)
+
+    def __mul__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) * other
+
+    def __rmul__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) * other
+
+    def __truediv__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) / other
+
+    def __le__(self, other: Any) -> LpConstraint:
+        return LpAffineExpression(self) <= other
+
+    def __ge__(self, other: Any) -> LpConstraint:
+        return LpAffineExpression(self) >= other
+
+    def __eq__(  # pyright: ignore [reportIncompatibleMethodOverride]
+        self, other: Any
+    ) -> LpConstraint:
+        return LpAffineExpression(self) == other
+
+    def __ne__(self, other: Any) -> bool:
+        if isinstance(other, LpVariable):
+            return self.name is not other.name
+        elif isinstance(other, (LpAffineExpression, LpConstraint)):
+            if other.isAtomic():
+                return self is not other.atom()
+            else:
+                return True
+        else:
+            return True
+
+
+class LpAffineExpression(dict[LptVars, LptNumber]):
     """
     A linear combination of :class:`LpVariables<LpVariable>`.
     Can be initialised with the following:
@@ -699,15 +835,13 @@ class LpAffineExpression(dict[LpVariable, float]):
         self,
         e: (
             LpAffineExpression
-            | LpConstraint
-            | dict[LpVariable, float]
-            | Iterable[tuple[LpVariable, float]]
-            | LpVariable
-            | int
-            | float
+            | LptVars
+            | dict[LptVars, LptNumber]
+            | Iterable[tuple[LptVars, LptNumber]]
+            | LptItem
             | None
         ) = None,
-        constant: int | float = 0.0,
+        constant: int | float = 0,
         name: str | None = None,
     ):
         self.name = name
@@ -716,20 +850,16 @@ class LpAffineExpression(dict[LpVariable, float]):
             # Will not copy the name
             self.constant = e.constant
             super().__init__(e.items())
-        elif isinstance(e, dict):
+        elif isinstance(e, (dict, Iterable)):
             self.constant = constant
             super().__init__(e)
-        elif isinstance(e, Iterable):
+        elif isinstance(e, (LpVariable, LpConstraintVar)):
             self.constant = constant
-            super().__init__(e)
-        elif isinstance(e, LpVariable):
-            self.constant = 0
             super().__init__([(e, 1)])
         elif e is None:
             self.constant = constant
             super().__init__()
         else:
-            assert e is not LpElement
             self.constant = e
             super().__init__()
 
@@ -741,7 +871,7 @@ class LpAffineExpression(dict[LpVariable, float]):
     def isNumericalConstant(self) -> bool:
         return len(self) == 0
 
-    def atom(self) -> LpVariable:
+    def atom(self) -> LptVars:
         return next(iter(self.keys()))
 
     # Functions on expressions
@@ -752,18 +882,19 @@ class LpAffineExpression(dict[LpVariable, float]):
     def value(self) -> float | None:
         s = self.constant
         for v, x in self.items():
-            if v.varValue is None:
+            value = v.value()
+            if value is None:
                 return None
-            s += v.varValue * x
+            s += value * x
         return s
 
-    def valueOrDefault(self) -> float:
+    def valueOrDefault(self) -> LptNumber:
         s = self.constant
         for v, x in self.items():
             s += v.valueOrDefault() * x
         return s
 
-    def addterm(self, key: LpVariable, value: float | int):
+    def addterm(self, key: LptVars, value: LptNumber):
         if key in self:
             self[key] += value
         else:
@@ -808,7 +939,7 @@ class LpAffineExpression(dict[LpVariable, float]):
             s = "0"
         return s
 
-    def sorted_keys(self) -> list[LpVariable]:
+    def sorted_keys(self) -> list[LptVars]:
         """
         returns the list of keys sorted by name
         """
@@ -820,7 +951,7 @@ class LpAffineExpression(dict[LpVariable, float]):
         constant = constant = (
             self.constant if override_constant is None else override_constant
         )
-        l = [str(self[v]) + "*" + str(v) for v in self.sorted_keys()]
+        l = [f"{self[v]}*{v}" for v in self.sorted_keys()]
         l.append(str(constant))
         s = " + ".join(l)
         return s
@@ -889,12 +1020,16 @@ class LpAffineExpression(dict[LpVariable, float]):
             result.append("".join(line))
             line = [term]
         else:
-            line += [term]
+            line.append(term)
         result.append("".join(line))
         result.append("")
         return "\n".join(result)
 
-    def addInPlace(self, other, sign: Literal[+1, -1] = 1):
+    def addInPlace(
+        self,
+        other: LptExpr | LpConstraintVar | dict[str, LptVars] | Iterable[LptExpr],
+        sign: Literal[+1, -1] = 1,
+    ):
         """
         :param int sign: the sign of the operation to do other.
             if we add other => 1
@@ -904,36 +1039,39 @@ class LpAffineExpression(dict[LpVariable, float]):
             return self
         if other is None:
             return self
-        if isinstance(other, LpVariable):
+        if isinstance(other, (LpVariable, LpConstraintVar)):
             # if a variable, we add it to the dictionary
             self.addterm(other, sign)
-        elif isinstance(other, (LpAffineExpression, LpConstraint)):
+        elif isinstance(other, LpAffineExpression):
             # if an expression, we add each variable and the constant
             self.constant += other.constant * sign
             for v, x in other.items():
                 self.addterm(v, x * sign)
-        elif isinstance(other, LpConstraintVar):
-            raise NotImplementedError()
         elif isinstance(other, dict):
             # if a dictionary, we add each value
             for e in other.values():
+                assert isinstance(e, LpVariable)
                 self.addInPlace(e, sign=sign)
         elif isinstance(other, Iterable):
             # if a list, we add each element of the list
             for e in other:
                 self.addInPlace(e, sign=sign)
         # if it's indeed a number, we add it to the constant
-        elif isinstance(other, (int, float)):
+        elif isinstance(
+            other, (int, float)
+        ):  # pyright: ignore [reportUnnecessaryIsInstance]
             # if we're here, other must be a number
             # we check if it's an actual number:
             if not math.isfinite(other):
                 raise const.PulpError("Cannot add/subtract NaN/inf values")
             self.constant += other * sign
         else:
-            raise TypeError()
+            raise TypeError(f"Unsupported type {type(other)}")
         return self
 
-    def subInPlace(self, other):
+    def subInPlace(
+        self, other: LptExpr | LpConstraintVar | dict[str, LptVars] | Iterable[LptExpr]
+    ):
         return self.addInPlace(other, sign=-1)
 
     def __neg__(self):
@@ -946,27 +1084,27 @@ class LpAffineExpression(dict[LpVariable, float]):
     def __pos__(self):
         return self
 
-    def __add__(self, other):
+    def __add__(self, other: LptExpr):
         return self.copy().addInPlace(other)
 
-    def __radd__(self, other):
+    def __radd__(self, other: LptExpr):
         return self.copy().addInPlace(other)
 
-    def __iadd__(self, other):
+    def __iadd__(self, other: LptExpr):
         return self.addInPlace(other)
 
-    def __sub__(self, other):
+    def __sub__(self, other: LptExpr):
         return self.copy().subInPlace(other)
 
-    def __rsub__(self, other):
+    def __rsub__(self, other: LptExpr):
         return (-self).addInPlace(other)
 
-    def __isub__(self, other):
+    def __isub__(self, other: LptExpr):
         return (self).subInPlace(other)
 
-    def __mul__(self, other) -> LpAffineExpression:
+    def __mul__(self, other: LptExpr) -> LpAffineExpression:
         e = self.emptyCopy()
-        if isinstance(other, (LpAffineExpression, LpConstraint)):
+        if isinstance(other, LpAffineExpression):
             e.constant = self.constant * other.constant
             if len(other):
                 if len(self):
@@ -992,11 +1130,11 @@ class LpAffineExpression(dict[LpVariable, float]):
                     e[v] = other * x
         return e
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: LptExpr):
         return self * other
 
-    def __truediv__(self, other) -> LpAffineExpression:
-        if isinstance(other, (LpAffineExpression, LpConstraint)):
+    def __truediv__(self, other: LptConstExpr) -> LpAffineExpression:
+        if isinstance(other, LpAffineExpression):
             if len(other):
                 raise TypeError(
                     "Expressions cannot be divided by a non-constant expression"
@@ -1010,14 +1148,14 @@ class LpAffineExpression(dict[LpVariable, float]):
             e[v] = x / other
         return e
 
-    def __rdiv__(self, other):
+    def __rdiv__(self, other: LptConstExpr):
         e = self.emptyCopy()
         if len(self):
             raise TypeError(
                 "Expressions cannot be divided by a non-constant expression"
             )
         c = self.constant
-        if isinstance(other, (LpAffineExpression, LpConstraint)):
+        if isinstance(other, LpAffineExpression):
             e.constant = other.constant / c
             for v, x in other.items():
                 e[v] = x / c
@@ -1027,25 +1165,27 @@ class LpAffineExpression(dict[LpVariable, float]):
             e.constant = other / c
         return e
 
-    def __le__(self, other) -> LpConstraint:
+    def __le__(self, other: LptExpr) -> LpConstraint:
         if isinstance(other, (int, float)):
             return LpConstraint(self, const.LpConstraintLE, rhs=other)
         else:
             return LpConstraint(self - other, const.LpConstraintLE)
 
-    def __ge__(self, other) -> LpConstraint:
+    def __ge__(self, other: LptExpr) -> LpConstraint:
         if isinstance(other, (int, float)):
             return LpConstraint(self, const.LpConstraintGE, rhs=other)
         else:
             return LpConstraint(self - other, const.LpConstraintGE)
 
-    def __eq__(self, other) -> LpConstraint:  # type: ignore
+    def __eq__(  # pyright: ignore [reportIncompatibleMethodOverride]
+        self, other: LptExpr
+    ) -> LpConstraint:
         if isinstance(other, (int, float)):
             return LpConstraint(self, const.LpConstraintEQ, rhs=other)
         else:
             return LpConstraint(self - other, const.LpConstraintEQ)
 
-    def toDict(self) -> list[dict[str, Any]]:
+    def toDataclass(self) -> list[mpslp.MPSCoefficient]:
         """
         exports the :py:class:`LpAffineExpression` into a list of dictionaries with the coefficients
         it does not export the constant
@@ -1053,9 +1193,7 @@ class LpAffineExpression(dict[LpVariable, float]):
         :return: list of dictionaries with the coefficients
         :rtype: list
         """
-        return [{"name": k.name, "value": v} for k, v in self.items()]
-
-    to_dict = toDict
+        return [mpslp.MPSCoefficient(name=k.name, value=v) for k, v in self.items()]
 
 
 class LpConstraint:
@@ -1063,10 +1201,10 @@ class LpConstraint:
 
     def __init__(
         self,
-        e=None,
+        e: LptExpr | None = None,
         sense: int = const.LpConstraintEQ,
         name: str | None = None,
-        rhs: int | float | None = None,
+        rhs: LptNumber | None = None,
     ):
         """
         :param e: an instance of :class:`LpAffineExpression`
@@ -1083,10 +1221,9 @@ class LpConstraint:
                 "sense must be one of const.LpConstraintEQ, const.LpConstraintLE, const.LpConstraintGE"
             )
 
-        self.expr = (
-            e if isinstance(e, LpAffineExpression) else LpAffineExpression(e, name=name)
-        )
-        self.constant: float = self.expr.constant
+        self.expr = e if isinstance(e, LpAffineExpression) else LpAffineExpression(e)
+        self.name = name
+        self.constant: LptNumber = self.expr.constant
         if rhs is not None:
             self.constant -= rhs
         self.sense = sense
@@ -1094,13 +1231,13 @@ class LpConstraint:
         self.slack: float | None = None
         self.modified: bool = True
 
-    def getLb(self) -> float | None:
+    def getLb(self) -> LptNumber | None:
         if (self.sense == const.LpConstraintGE) or (self.sense == const.LpConstraintEQ):
             return -self.constant
         else:
             return None
 
-    def getUb(self) -> float | None:
+    def getUb(self) -> LptNumber | None:
         if (self.sense == const.LpConstraintLE) or (self.sense == const.LpConstraintEQ):
             return -self.constant
         else:
@@ -1108,33 +1245,31 @@ class LpConstraint:
 
     def __str__(self):
         s = self.expr.__str__(include_constant=False, override_constant=self.constant)
-        if self.sense is not None:
-            s += " " + const.LpConstraintSenses[self.sense] + " " + str(-self.constant)
+        s += " " + const.LpConstraintSenses[self.sense] + " " + str(-self.constant)
         return s
 
     def __repr__(self):
         s = self.expr.__repr__(override_constant=self.constant)
-        if self.sense is not None:
-            s += " " + const.LpConstraintSenses[self.sense] + " 0"
+        s += " " + const.LpConstraintSenses[self.sense] + " 0"
         return s
 
-    def asCplexLpConstraint(self, name):
+    def asCplexLpConstraint(self, name: str) -> str:
         """
         Returns a constraint as a string
         """
         result, line = self.expr.asCplexVariablesOnly(name)
         if len(self.keys()) == 0:
-            line += ["0"]
+            line.append("0")
         c = -self.constant
         if c == 0:
             c = 0  # Supress sign
         term = f" {const.LpConstraintSenses[self.sense]} {c:.12g}"
         if self.expr._count_characters(line) + len(term) > const.LpCplexLPLineSize:
-            result += ["".join(line)]
+            result.append("".join(line))
             line = [term]
         else:
-            line += [term]
-        result += ["".join(line)]
+            line.append(term)
+        result.append("".join(line))
         result = "%s\n" % "\n".join(result)
         return result
 
@@ -1162,7 +1297,7 @@ class LpConstraint:
     def emptyCopy(self):
         return LpConstraint(sense=self.sense)
 
-    def addInPlace(self, other, sign: Literal[+1, -1] = 1):
+    def addInPlace(self, other: LptExprConstraint, sign: Literal[+1, -1] = 1):
         """
         :param int sign: the sign of the operation to do other.
             if we add other => 1
@@ -1180,13 +1315,15 @@ class LpConstraint:
         elif isinstance(other, LpAffineExpression):
             self.constant += other.constant * sign
             self.expr.addInPlace(other, sign)
-        elif isinstance(other, LpVariable):
+        elif isinstance(
+            other, LpVariable
+        ):  # pyright: ignore [reportUnnecessaryIsInstance]
             self.expr.addInPlace(other, sign)
         else:
             raise TypeError(f"Constraints and {type(other)} cannot be added")
         return self
 
-    def subInPlace(self, other):
+    def subInPlace(self, other: LptExprConstraint):
         return self.addInPlace(other, -1)
 
     def __neg__(self):
@@ -1195,25 +1332,27 @@ class LpConstraint:
         c.expr = -c.expr
         return c
 
-    def __add__(self, other):
+    def __add__(self, other: LptExprConstraint):
         return self.copy().addInPlace(other)
 
-    def __radd__(self, other):
+    def __radd__(self, other: LptExprConstraint):
         return self.copy().addInPlace(other)
 
-    def __sub__(self, other):
+    def __sub__(self, other: LptExprConstraint):
         return self.copy().subInPlace(other)
 
-    def __rsub__(self, other):
+    def __rsub__(self, other: LptExprConstraint):
         return (-self).addInPlace(other)
 
-    def __mul__(self, other):
+    def __mul__(self, other: LptConstExpr):
         if isinstance(other, (int, float)):
             c = self.copy()
             c.constant = c.constant * other
             c.expr = c.expr * other
             return c
-        elif isinstance(other, LpAffineExpression):
+        elif isinstance(
+            other, LpAffineExpression
+        ):  # pyright: ignore [reportUnnecessaryIsInstance]
             c = self.copy()
             c.constant = c.constant * other.constant
             c.expr = c.expr * other
@@ -1221,16 +1360,18 @@ class LpConstraint:
         else:
             raise TypeError(f"Cannot multiple LpConstraint by {type(other)}")
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: LptConstExpr):
         return self * other
 
-    def __truediv__(self, other):
+    def __truediv__(self, other: LptConstExpr):
         if isinstance(other, (int, float)):
             c = self.copy()
             c.constant = c.constant / other
             c.expr = c.expr / other
             return c
-        elif isinstance(other, LpAffineExpression):
+        elif isinstance(
+            other, LpAffineExpression
+        ):  # pyright: ignore [reportUnnecessaryIsInstance]
             c = self.copy()
             c.constant = c.constant / other.constant
             c.expr = c.expr / other
@@ -1255,22 +1396,24 @@ class LpConstraint:
         """
         return FixedElasticSubProblem(self, *args, **kwargs)
 
-    def toDict(self):
+    def toDataclass(self) -> mpslp.MPSConstraint:
         """
         exports constraint information into a dictionary
 
         :return: dictionary with all the constraint information
         """
-        return dict(
+        return mpslp.MPSConstraint(
             sense=self.sense,
             pi=self.pi,
             constant=self.constant,
             name=self.name,
-            coefficients=self.expr.toDict(),
+            coefficients=self.expr.toDataclass(),
         )
 
     @classmethod
-    def fromDict(cls, _dict):
+    def fromDataclass(
+        cls, mps: mpslp.MPSConstraint, variables: dict[str, LpVariable]
+    ) -> LpConstraint:
         """
         Initializes a constraint object from a dictionary with necessary information
 
@@ -1278,23 +1421,29 @@ class LpConstraint:
         :return: a new :py:class:`LpConstraint`
         """
         const = cls(
-            e=_dict["coefficients"],
-            rhs=-_dict["constant"],
-            name=_dict["name"],
-            sense=_dict["sense"],
+            e=LpAffineExpression(
+                {
+                    variables[coefficient.name]: coefficient.value
+                    for coefficient in mps.coefficients
+                }
+            ),
+            sense=mps.sense,
+            name=mps.name,
+            rhs=-mps.constant,
         )
-        const.pi = _dict["pi"]
+        const.pi = mps.pi
         return const
 
-    from_dict = fromDict
-
     @property
-    def name(self):
-        return self.expr.name
+    def name(self) -> str | None:
+        return self.__name
 
     @name.setter
-    def name(self, v: str):
-        self.expr.name = v
+    def name(self, name: str | None):
+        if name is not None:
+            self.__name = name.translate(LpAffineExpression.trans)
+        else:
+            self.__name = None
 
     def isAtomic(self) -> bool:
         return len(self) == 1 and self.constant == 0 and next(iter(self.values())) == 1
@@ -1302,7 +1451,7 @@ class LpConstraint:
     def isNumericalConstant(self) -> bool:
         return self.expr.isNumericalConstant()
 
-    def atom(self) -> LpVariable:
+    def atom(self) -> LptVars:
         return self.expr.atom()
 
     def __bool__(self) -> bool:
@@ -1314,10 +1463,10 @@ class LpConstraint:
     def __iter__(self):
         return iter(self.expr)
 
-    def __getitem__(self, key: LpVariable) -> float:
+    def __getitem__(self, key: LptVars) -> float:
         return self.expr[key]
 
-    def get(self, key: LpVariable, default: float | None) -> float | None:
+    def get(self, key: LptVars, default: float | None) -> float | None:
         return self.expr.get(key, default)
 
     def keys(self):
@@ -1332,9 +1481,10 @@ class LpConstraint:
     def value(self) -> float | None:
         s = self.constant
         for v, x in self.items():
-            if v.varValue is None:
+            value = v.value()
+            if value is None:
                 return None
-            s += v.varValue * x
+            s += value * x
         return s
 
     def valueOrDefault(self) -> float:
@@ -1351,12 +1501,12 @@ class LpFractionConstraint(LpConstraint):
 
     def __init__(
         self,
-        numerator: float,
-        denominator: float | None = None,
+        numerator: LptExpr,
+        denominator: LptExpr | None = None,
         sense: int = const.LpConstraintEQ,
         RHS: float = 1.0,
         name: str | None = None,
-        complement=None,
+        complement: LptExpr | None = None,
     ):
         """
         creates a fraction Constraint to model constraints of
@@ -1380,18 +1530,31 @@ class LpFractionConstraint(LpConstraint):
         else:
             self.denominator = denominator
             self.complement = complement
+        if self.denominator is None:
+            raise ValueError("denominator is None")
         lhs = self.numerator - RHS * self.denominator
-        LpConstraint.__init__(self, lhs, sense=sense, rhs=0, name=name)
+        super().__init__(lhs, sense=sense, rhs=0, name=name)
         self.RHS = RHS
 
-    def findLHSValue(self):
+    def findLHSValue(self) -> float:
         """
         Determines the value of the fraction in the constraint after solution
         """
-        if abs(value(self.denominator)) >= const.EPS:
-            return value(self.numerator) / value(self.denominator)
+        if self.denominator is None:
+            raise ValueError("denominator is None")
+
+        denominator = value(self.denominator)
+        numerator = value(self.numerator)
+
+        if denominator is None:
+            raise ValueError("denominator is None")
+        if numerator is None:
+            raise ValueError("numerator is None")
+
+        if abs(denominator) >= const.EPS:
+            return numerator / denominator
         else:
-            if abs(value(self.numerator)) <= const.EPS:
+            if abs(numerator) <= const.EPS:
                 # zero divided by zero will return 1
                 return 1.0
             else:
@@ -1407,7 +1570,7 @@ class LpFractionConstraint(LpConstraint):
         return FractionElasticSubProblem(self, *args, **kwargs)
 
 
-class LpConstraintVar(LpElement):
+class LpConstraintVar:
     """A Constraint that can be treated as a variable when constructing
     a LpProblem by columns
     """
@@ -1415,12 +1578,31 @@ class LpConstraintVar(LpElement):
     def __init__(
         self,
         name: str | None = None,
-        sense: int | None = None,
+        sense: int = const.LpConstraintEQ,
         rhs: int | float | None = None,
-        e=None,
+        e: LptExpr | None = None,
     ):
-        super().__init__(name)
+        # self.hash MUST be different for each variable
+        # else dict() will call the comparison operators that are overloaded
+        self.hash = id(self)
+        self.modified: bool = True
+        self.name = name
         self.constraint = LpConstraint(name=self.name, sense=sense, rhs=rhs, e=e)
+
+    @property
+    def name(self) -> str | None:
+        return self.__name
+
+    @name.setter
+    def name(self, name: str | None):
+        if name is not None:
+            if NAME_EXPRESSION.match(name):
+                warnings.warn(
+                    f"The name {name} has illegal characters that will be replaced by _"
+                )
+            self.__name = name.translate(NAME_TRANS)
+        else:
+            self.__name = None
 
     def addVariable(self, var: LpVariable, coeff: int | float):
         """
@@ -1431,6 +1613,64 @@ class LpConstraintVar(LpElement):
 
     def value(self) -> float | None:
         return self.constraint.value()
+
+    def valueOrDefault(self) -> float:
+        return self.constraint.valueOrDefault()
+
+    def __hash__(self):
+        return self.hash
+
+    def __neg__(self) -> LpAffineExpression:
+        return -LpAffineExpression(self)
+
+    def __pos__(self):
+        return self
+
+    def __bool__(self) -> bool:
+        return True
+
+    def __add__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) + other
+
+    def __radd__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) + other
+
+    def __sub__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) - other
+
+    def __rsub__(self, other: Any) -> LpAffineExpression:
+        return other - LpAffineExpression(self)
+
+    def __mul__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) * other
+
+    def __rmul__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) * other
+
+    def __truediv__(self, other: Any) -> LpAffineExpression:
+        return LpAffineExpression(self) / other
+
+    def __le__(self, other: Any) -> LpConstraint:
+        return LpAffineExpression(self) <= other
+
+    def __ge__(self, other: Any) -> LpConstraint:
+        return LpAffineExpression(self) >= other
+
+    def __eq__(  # pyright: ignore [reportIncompatibleMethodOverride]
+        self, other: Any
+    ) -> LpConstraint:
+        return LpAffineExpression(self) == other
+
+    def __ne__(self, other: Any) -> bool:
+        if isinstance(other, LpConstraintVar):
+            return self.name is not other.name
+        elif isinstance(other, (LpAffineExpression, LpConstraint)):
+            if other.isAtomic():
+                return self is not other.atom()
+            else:
+                return True
+        else:
+            return True
 
 
 class LpProblem:
@@ -1464,23 +1704,23 @@ class LpProblem:
         self.constraints: dict[str, LpConstraint] = {}
         self.name = name
         self.sense = sense
-        self.sos1 = {}
-        self.sos2 = {}
+        self.sos1: dict[int, Any] = {}
+        self.sos2: dict[int, Any] = {}
         self.status = const.LpStatusNotSolved
         self.sol_status = const.LpSolutionNoSolutionFound
         self.noOverlap = True
-        self.solver = None
-        self.solverModel = None
-        self.modifiedVariables = []
-        self.modifiedConstraints = []
-        self.resolveOK = False
-        self._variables: list[LpVariable] = []
-        self._variable_ids: dict[int, LpVariable] = (
+        self.solver: LpSolver | None = None
+        self.solverModel: Any | None = None
+        self.modifiedVariables: list[LpVariable] = []
+        self.modifiedConstraints: list[LpConstraint] = []
+        self.resolveOK: bool = False
+        self._variables: list[LptVars] = []
+        self._variable_ids: dict[int, LptVars] = (
             {}
         )  # old school using dict.keys() for a set
-        self.dummyVar = None
-        self.solutionTime = 0
-        self.solutionCpuTime = 0
+        self.dummyVar: LpVariable | None = None
+        self.solutionTime: float = 0.0
+        self.solutionCpuTime: float = 0.0
 
         # locals
         self.lastUnused = 0
@@ -1502,13 +1742,13 @@ class LpProblem:
             s += v.asCplexLpVariable() + " " + const.LpCategories[v.cat] + "\n"
         return s
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         # Remove transient data prior to pickling.
         state = self.__dict__.copy()
         del state["_variable_ids"]
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, Any]):
         # Update transient data prior to unpickling.
         self.__dict__.update(state)
         self._variable_ids = {}
@@ -1536,7 +1776,7 @@ class LpProblem:
         lpcopy.sos2 = self.sos2.copy()
         return lpcopy
 
-    def toDict(self):
+    def toDataclass(self) -> mpslp.MPS:
         """
         creates a dictionary from the model with as much data as possible.
         It replaces variables by variable names.
@@ -1554,13 +1794,13 @@ class LpProblem:
         self.fixObjective()
         assert self.objective is not None
         variables = self.variables()
-        return dict(
-            objective=dict(
-                name=self.objective.name, coefficients=self.objective.toDict()
+        return mpslp.MPS(
+            objective=mpslp.MPSObjective(
+                name=self.objective.name, coefficients=self.objective.toDataclass()
             ),
-            constraints=[v.toDict() for v in self.constraints.values()],
-            variables=[v.toDict() for v in variables],
-            parameters=dict(
+            constraints=[v.toDataclass() for v in self.constraints.values()],
+            variables=[v.toDataclass() for v in variables],
+            parameters=mpslp.MPSParameters(
                 name=self.name,
                 sense=self.sense,
                 status=self.status,
@@ -1570,60 +1810,42 @@ class LpProblem:
             sos2=list(self.sos2.values()),
         )
 
-    to_dict = toDict
-
     @classmethod
-    def fromDict(cls, _dict):
+    def fromDataclass(cls, mps: mpslp.MPS) -> tuple[dict[str, LpVariable], LpProblem]:
         """
         Takes a dictionary with all necessary information to build a model.
         And returns a dictionary of variables and a problem object
 
-        :param _dict: dictionary with the model stored
+        :param mps: dictionary with the model stored
         :return: a tuple with a dictionary of variables and a :py:class:`LpProblem`
         """
 
         # we instantiate the problem
-        params = _dict["parameters"]
-        pb_params = {"name", "sense"}
-        args = {k: params[k] for k in pb_params}
-        pb = cls(**args)
-        pb.status = params["status"]
-        pb.sol_status = params["sol_status"]
+        pb = cls(name=mps.parameters.name, sense=mps.parameters.sense)
+        pb.status = mps.parameters.status
+        pb.sol_status = mps.parameters.sol_status
 
         # recreate the variables.
-        var = {v["name"]: LpVariable.fromDict(**v) for v in _dict["variables"]}
+        var: dict[str, LpVariable] = {
+            v.name: LpVariable.fromDataclass(v) for v in mps.variables
+        }
 
         # objective function.
         # we change the names for the objects:
-        obj_e = {
-            var[v["name"]]: float(v["value"])
-            for v in _dict["objective"]["coefficients"]
-        }
-        pb += LpAffineExpression(e=obj_e, name=_dict["objective"]["name"])
+        obj_e = {var[v.name]: v.value for v in mps.objective.coefficients}
+        pb += LpAffineExpression(e=obj_e, name=mps.objective.name)
 
         # constraints
-        # we change the names for the objects:
-        def edit_const(const):
-            const = dict(const)
-            const["coefficients"] = {
-                var[v["name"]]: v["value"] for v in const["coefficients"]
-            }
-            return const
-
-        constraints = [edit_const(v) for v in _dict["constraints"]]
-        for c in constraints:
-            pb += LpConstraint.fromDict(c)
+        for c in mps.constraints:
+            pb += LpConstraint.fromDataclass(c, var)
 
         # last, parameters, other options
-        list_to_dict = lambda v: {k: v for k, v in enumerate(v)}
-        pb.sos1 = list_to_dict(_dict["sos1"])
-        pb.sos2 = list_to_dict(_dict["sos2"])
+        pb.sos1 = dict(enumerate(mps.sos1))
+        pb.sos2 = dict(enumerate(mps.sos2))
 
         return var, pb
 
-    from_dict = fromDict
-
-    def toJson(self, filename, *args, **kwargs):
+    def toJson(self, filename: str, *args: Any, **kwargs: Any):
         """
         Creates a json file from the LpProblem information
 
@@ -1633,14 +1855,14 @@ class LpProblem:
         :return: None
         """
         with open(filename, "w") as f:
-            json.dump(self.toDict(), f, *args, **kwargs)
+            json.dump(dataclasses.asdict(self.toDataclass()), f, *args, **kwargs)
 
     to_json = toJson
 
     @classmethod
-    def fromJson(cls, filename):
+    def fromJson(cls, filename: str) -> tuple[dict[str, LpVariable], LpProblem]:
         """
-        Creates a new Lp Problem from a json file with information
+        Creates a new LpProblem from a json file with information
 
         :param str filename: json file name
         :return: a tuple with a dictionary of variables and an LpProblem
@@ -1648,14 +1870,16 @@ class LpProblem:
         """
         with open(filename) as f:
             data = json.load(f)
-        return cls.fromDict(data)
+        return cls.fromDataclass(dacite.from_dict(mpslp.MPS, data))
 
     from_json = fromJson
 
     @classmethod
-    def fromMPS(cls, filename, sense=const.LpMinimize, **kwargs):
-        data = mpslp.readMPS(filename, sense=sense, **kwargs)
-        return cls.fromDict(data)
+    def fromMPS(
+        cls, filename: str, sense: int = const.LpMinimize, dropConsNames: bool = False
+    ):
+        data = mpslp.readMPS(filename, sense=sense, dropConsNames=dropConsNames)
+        return cls.fromDataclass(data)
 
     def normalisedNames(self):
         constraintsNames = {k: "C%07d" % i for i, k in enumerate(self.constraints)}
@@ -1663,13 +1887,10 @@ class LpProblem:
         variablesNames = {k.name: "X%07d" % i for i, k in enumerate(_variables)}
         return constraintsNames, variablesNames, "OBJ"
 
-    def isMIP(self):
-        for v in self.variables():
-            if v.cat == const.LpInteger:
-                return 1
-        return 0
+    def isMIP(self) -> bool:
+        return any(v.cat == const.LpInteger for v in self.variables())
 
-    def roundSolution(self, epsInt=1e-5, eps=1e-7):
+    def roundSolution(self, epsInt: float = 1e-5, eps: float = 1e-7):
         """
         Rounds the lp variables
 
@@ -1682,7 +1903,7 @@ class LpProblem:
         for v in self.variables():
             v.round(epsInt, eps)
 
-    def unusedConstraintName(self):
+    def unusedConstraintName(self) -> str:
         self.lastUnused += 1
         while True:
             s = "_C%d" % self.lastUnused
@@ -1691,15 +1912,14 @@ class LpProblem:
             self.lastUnused += 1
         return s
 
-    def valid(self, eps: float | int = 0):
+    def valid(self, eps: LptNumber = 0) -> bool:
         for v in self.variables():
             if not v.valid(eps):
                 return False
         for c in self.constraints.values():
             if not c.valid(eps):
                 return False
-        else:
-            return True
+        return True
 
     def infeasibilityGap(self, mip: bool = True) -> float:
         gap = 0.0
@@ -1712,7 +1932,7 @@ class LpProblem:
                 gap = max(abs(value), gap)
         return gap
 
-    def addVariable(self, variable: LpVariable):
+    def addVariable(self, variable: LptVars):
         """
         Adds a variable to the problem before a constraint is added
 
@@ -1722,7 +1942,7 @@ class LpProblem:
             self._variables.append(variable)
             self._variable_ids[variable.hash] = variable
 
-    def addVariables(self, variables: Iterable[LpVariable]):
+    def addVariables(self, variables: Iterable[LptVars]):
         """
         Adds variables to the problem before a constraint is added
 
@@ -1731,7 +1951,7 @@ class LpProblem:
         for v in variables:
             self.addVariable(v)
 
-    def variables(self) -> list[LpVariable]:
+    def variables(self) -> list[LptVars]:
         """
         Returns the problem variables
 
@@ -1745,13 +1965,15 @@ class LpProblem:
         self._variables.sort(key=lambda v: v.name)
         return self._variables
 
-    def variablesDict(self) -> dict[str, LpVariable]:
-        variables: dict[str, LpVariable] = {}
+    def variablesDict(self) -> dict[str, LptVars]:
+        variables: dict[str, LptVars] = {}
         if self.objective:
             for v in self.objective:
+                assert v.name is not None
                 variables[v.name] = v
         for c in self.constraints.values():
             for v in c:
+                assert v.name is not None
                 variables[v.name] = v
         return variables
 
@@ -1759,17 +1981,14 @@ class LpProblem:
         self.addConstraint(constraint, name)
 
     def addConstraint(self, constraint: LpConstraint, name: str | None = None):
-        if not isinstance(constraint, LpConstraint):
-            raise TypeError("Can only add LpConstraint objects")
-        if name:
+        # Set name if given one
+        if name is not None:
             constraint.name = name
-        try:
-            if constraint.name:
-                name = constraint.name
-            else:
-                name = self.unusedConstraintName()
-        except AttributeError:
-            raise TypeError("Can only add LpConstraint objects")
+
+        if constraint.name is not None:
+            name = constraint.name
+        else:
+            name = self.unusedConstraintName()
             # removed as this test fails for empty constraints
         #        if len(constraint) == 0:
         #            if not constraint.valid():
@@ -1796,21 +2015,30 @@ class LpProblem:
             # allows the user to add a LpVariable as an objective
             obj = LpAffineExpression(obj)
 
-        try:
-            obj = obj.constraint
+        name: str | None = None
+
+        if isinstance(obj, LpConstraintVar):
+            obj = obj.constraint.expr
             name = obj.name
-        except AttributeError:
-            name = None
 
         self.objective = obj
         self.objective.name = name
         self.resolveOK = False
 
-    def __iadd__(self, other):
+    def __iadd__(
+        self,
+        other: (
+            tuple[bool | LpConstraintVar | LptExprConstraint, str]
+            | bool
+            | LpConstraintVar
+            | LptExprConstraint
+        ),
+    ):
         if isinstance(other, tuple):
             other, name = other
         else:
             name = None
+
         if other is True:
             return self
         elif other is False:
@@ -1826,11 +2054,12 @@ class LpProblem:
             if name is not None:
                 # we may keep the LpAffineExpression name
                 self.objective.name = name
-        elif isinstance(other, (LpVariable, int, float)):
+        elif isinstance(
+            other, (LpVariable, int, float)
+        ):  # pyright: ignore [reportUnnecessaryIsInstance]
             if self.objective is not None:
                 warnings.warn("Overwriting previously set objective.")
-            self.objective = LpAffineExpression(other)
-            self.objective.name = name
+            self.objective = LpAffineExpression(other, name=name)
         else:
             raise TypeError(
                 "Can only add LpConstraintVar, LpConstraint, LpAffineExpression or True objects"
@@ -1860,6 +2089,7 @@ class LpProblem:
         """
         if isinstance(other, dict):
             for name, constraint in other.items():
+                assert isinstance(name, str)
                 assert isinstance(constraint, LpConstraint)
                 self.constraints[name] = constraint
         elif isinstance(other, LpProblem):
@@ -1869,10 +2099,14 @@ class LpProblem:
                 c.name = other.name + name
                 self.addConstraint(c)
             if use_objective:
+                if self.objective is None:
+                    raise ValueError("Objective is None")
                 if other.objective is None:
                     raise ValueError("Objective not set by provided problem")
                 self.objective += other.objective
-        elif isinstance(other, Iterable):
+        elif isinstance(
+            other, Iterable
+        ):  # pyright: ignore [reportUnnecessaryIsInstance]
             for c in other:
                 if isinstance(c, tuple):
                     name = c[0]
@@ -1887,21 +2121,39 @@ class LpProblem:
         else:
             raise TypeError()
 
-    def coefficients(self, translation=None):
-        coefs = []
-        if translation == None:
-            for c in self.constraints:
-                cst = self.constraints[c]
-                coefs.extend([(v.name, c, cst[v]) for v in cst])
+    @overload
+    def coefficients(
+        self, translation: dict[str | None, T]
+    ) -> list[tuple[T, T, float]]: ...
+
+    @overload
+    def coefficients(
+        self, translation: None = None
+    ) -> list[tuple[str, str, float]]: ...
+
+    def coefficients(
+        self, translation: dict[str | None, T] | None = None
+    ) -> list[tuple[str | None, str, float]] | list[tuple[T, T, float]]:
+        if translation is None:
+            return [
+                (k.name, c, v)
+                for c, cst in self.constraints.items()
+                for k, v in cst.items()
+            ]
         else:
-            for c in self.constraints:
-                ctr = translation[c]
-                cst = self.constraints[c]
-                coefs.extend([(translation[v.name], ctr, cst[v]) for v in cst])
-        return coefs
+            return [
+                (translation[k.name], translation[c], v)
+                for c, cst in self.constraints.items()
+                for k, v in cst.items()
+            ]
 
     def writeMPS(
-        self, filename, mpsSense=0, rename=0, mip=1, with_objsense: bool = False
+        self,
+        filename: str,
+        mpsSense: int = 0,
+        rename: bool = False,
+        mip: bool = True,
+        with_objsense: bool = False,
     ):
         """
         Writes an mps files from the problem information
@@ -1924,7 +2176,13 @@ class LpProblem:
             with_objsense=with_objsense,
         )
 
-    def writeLP(self, filename, writeSOS=1, mip=1, max_length=100):
+    def writeLP(
+        self,
+        filename: str,
+        writeSOS: bool = True,
+        mip: bool = True,
+        max_length: int = 100,
+    ):
         """
         Write the given Lp problem to a .lp file.
 
@@ -1971,35 +2229,46 @@ class LpProblem:
                 f"Variable names too long for Lp format: {long_names}"
             )
 
-    def assignVarsVals(self, values):
+    def assignVarsVals(self, values: dict[str, float]):
         variables = self.variablesDict()
-        for name in values:
-            if name != "__dummy":
-                variables[name].varValue = values[name]
+        for name, value in values.items():
+            if name == "__dummy":
+                continue
 
-    def assignVarsDj(self, values):
+            var = variables[name]
+            if not isinstance(var, LpVariable):
+                continue
+
+            var.varValue = value
+
+    def assignVarsDj(self, values: dict[str, float]):
         variables = self.variablesDict()
-        for name in values:
-            if name != "__dummy":
-                variables[name].dj = values[name]
+        for name, value in values.items():
+            if name == "__dummy":
+                continue
 
-    def assignConsPi(self, values):
-        for name in values:
+            var = variables[name]
+            if not isinstance(var, LpVariable):
+                continue
+
+            var.dj = value
+
+    def assignConsPi(self, values: dict[str, float]):
+        for name, value in values.items():
             try:
-                self.constraints[name].pi = values[name]
+                self.constraints[name].pi = value
             except KeyError:
                 pass
 
-    def assignConsSlack(self, values, activity=False):
-        for name in values:
+    def assignConsSlack(self, values: dict[str, float], activity: bool = False):
+        for name, value in values.items():
             try:
+                constraint = self.constraints[name]
                 if activity:
                     # reports the activity not the slack
-                    self.constraints[name].slack = -1 * (
-                        self.constraints[name].constant + float(values[name])
-                    )
+                    constraint.slack = -1 * constraint.constant + value
                 else:
-                    self.constraints[name].slack = float(values[name])
+                    constraint.slack = value
             except KeyError:
                 pass
 
@@ -2023,10 +2292,10 @@ class LpProblem:
 
         return wasNone, dummyVar
 
-    def restoreObjective(self, wasNone, dummyVar):
+    def restoreObjective(self, wasNone: bool, dummyVar: LpVariable | None):
         if wasNone:
             self.objective = None
-        elif not dummyVar is None:
+        elif dummyVar is not None:
             self.objective -= dummyVar
 
     def solve(self, solver: LpSolver | None = None, **kwargs: Any):
@@ -2044,10 +2313,12 @@ class LpProblem:
               :meth:`~pulp.solver.LpSolver.actualSolve()` to reflect the Lp solution
         """
 
-        if not (solver):
+        if solver is None:
             solver = self.solver
-        if not (solver):
+        if solver is None:
             solver = LpSolverDefault
+        if solver is None:
+            raise ValueError("Unable to set solver")
         wasNone, dummyVar = self.fixObjective()
         # time it
         self.startClock()
@@ -2074,7 +2345,7 @@ class LpProblem:
         relativeTols: list[float] | None = None,
         solver: LpSolver | None = None,
         debug: bool = False,
-    ):
+    ) -> list[int]:
         """
         Solve the given Lp problem with several objective functions.
 
@@ -2103,7 +2374,7 @@ class LpProblem:
             relativeTols = [1.0] * len(objectives)
         # time it
         self.startClock()
-        statuses = []
+        statuses: list[int] = []
         for i, (obj, absol, rel) in enumerate(
             zip(objectives, absoluteTols, relativeTols)
         ):
@@ -2113,40 +2384,46 @@ class LpProblem:
             if debug:
                 self.writeLP(f"{i}Sequence.lp")
             if self.sense == const.LpMinimize:
-                self += obj <= value(obj) * rel + absol, f"Sequence_Objective_{i}"
+                obj_value = value(obj)
+                if obj_value is None:
+                    raise TypeError("objective is None")
+                self += obj <= obj_value * rel + absol, f"Sequence_Objective_{i}"
             elif self.sense == const.LpMaximize:
-                self += obj >= value(obj) * rel + absol, f"Sequence_Objective_{i}"
+                obj_value = value(obj)
+                if obj_value is None:
+                    raise TypeError("objective is None")
+                self += obj >= obj_value * rel + absol, f"Sequence_Objective_{i}"
         self.stopClock()
         self.solver = solver
         return statuses
 
-    def resolve(self, solver: LpSolver | None = None, **kwargs):
+    def resolve(self, solver: LpSolver | None = None, **kwargs: Any):
         """
         resolves an Problem using the same solver as previously
         """
-        if solver is not None:
+        if solver is None:
             solver = self.solver
         if solver is None:
-            raise const.PulpError("Failed to find default solver")
+            raise const.PulpError("No solver provided and no previous solver to use")
         if self.resolveOK:
             return solver.actualResolve(self, **kwargs)
         else:
             return self.solve(solver=solver, **kwargs)
 
-    def setSolver(self, solver=LpSolverDefault):
+    def setSolver(self, solver: LpSolver | None = LpSolverDefault):
         """Sets the Solver for this problem useful if you are using
         resolve
         """
         self.solver = solver
 
-    def numVariables(self):
+    def numVariables(self) -> int:
         """
 
         :return: number of variables in model
         """
         return len(self._variable_ids)
 
-    def numConstraints(self):
+    def numConstraints(self) -> int:
         """
 
         :return: number of constraints in model
@@ -2156,7 +2433,7 @@ class LpProblem:
     def getSense(self):
         return self.sense
 
-    def assignStatus(self, status, sol_status=None):
+    def assignStatus(self, status: int, sol_status: int | None = None):
         """
         Sets the status of the model after solving.
         :param status: code for the status of the model
@@ -2175,7 +2452,6 @@ class LpProblem:
                 status, const.LpSolutionNoSolutionFound
             )
         self.sol_status = sol_status
-        return True
 
 
 class FixedElasticSubProblem(LpProblem):
@@ -2323,15 +2599,15 @@ class FractionElasticSubProblem(FixedElasticSubProblem):
 
     def __init__(
         self,
-        name,
-        numerator,
-        RHS,
-        sense,
-        complement=None,
-        denominator=None,
-        penalty=None,
-        proportionFreeBound=None,
-        proportionFreeBoundList=None,
+        name: str,
+        numerator: LptExpr,
+        RHS: LptNumber,
+        sense: int,
+        complement: LptExpr | None = None,
+        denominator: LptExpr | None = None,
+        penalty: float | None = None,
+        proportionFreeBound: float | None = None,
+        proportionFreeBoundList: tuple[float, float] | None = None,
     ):
         subProblemName = f"{name}_elastic_SubProblem"
         self.numerator = numerator
@@ -2351,9 +2627,9 @@ class FractionElasticSubProblem(FixedElasticSubProblem):
         self.freeVar = LpVariable("_free_bound", upBound=0, lowBound=0)
         self.upVar = LpVariable("_pos_penalty_var", upBound=0, lowBound=0)
         self.lowVar = LpVariable("_neg_penalty_var", upBound=0, lowBound=0)
-        if proportionFreeBound:
-            proportionFreeBoundList = [proportionFreeBound, proportionFreeBound]
-        if proportionFreeBoundList:
+        if proportionFreeBound is not None:
+            proportionFreeBoundList = (proportionFreeBound, proportionFreeBound)
+        if proportionFreeBoundList is not None:
             upProportionFreeBound, lowProportionFreeBound = proportionFreeBoundList
         else:
             upProportionFreeBound, lowProportionFreeBound = (0, 0)
@@ -2400,10 +2676,21 @@ class FractionElasticSubProblem(FixedElasticSubProblem):
         rhs
         """
         # uses code from LpFractionConstraint
-        if abs(value(self.denominator)) >= const.EPS:
-            return value(self.numerator) / value(self.denominator)
+        if self.denominator is None:
+            raise ValueError("denominator is None")
+
+        denominator = value(self.denominator)
+        numerator = value(self.numerator)
+
+        if denominator is None:
+            raise ValueError("denominator is None")
+        if numerator is None:
+            raise ValueError("numerator is None")
+
+        if abs(denominator) >= const.EPS:
+            return numerator / denominator
         else:
-            if abs(value(self.numerator)) <= const.EPS:
+            if abs(numerator) <= const.EPS:
                 # zero divided by zero will return 1
                 return 1.0
             else:
@@ -2413,7 +2700,10 @@ class FractionElasticSubProblem(FixedElasticSubProblem):
         """
         returns true if the penalty variables are non-zero
         """
-        if abs(value(self.denominator)) >= const.EPS:
+        denominator = value(self.denominator)
+        if denominator is None:
+            raise ValueError("denominator is None")
+        if abs(denominator) >= const.EPS:
             if self.lowTarget is not None:
                 if self.lowTarget > self.findLHSValue():
                     return True
@@ -2425,15 +2715,7 @@ class FractionElasticSubProblem(FixedElasticSubProblem):
         return False
 
 
-def lpSum(
-    vector: (
-        Iterable[LpAffineExpression | LpVariable | int | float]
-        | Iterable[tuple[LpElement, float]]
-        | int
-        | float
-        | LpElement
-    ),
-):
+def lpSum(vector: Iterable[LpAffineExpression | LptItem] | LptItem):
     """
     Calculate the sum of a list of linear expressions
 
@@ -2442,17 +2724,30 @@ def lpSum(
     return LpAffineExpression().addInPlace(vector)
 
 
-def _vector_like(obj: Any) -> bool:
-    return isinstance(obj, Iterable) and not isinstance(obj, LpAffineExpression)
-
-
-def lpDot(v1, v2):
+def lpDot(
+    v1: Sequence[LpAffineExpression | LptItem] | LpAffineExpression | LptItem,
+    v2: Sequence[LpAffineExpression | LptItem] | LpAffineExpression | LptItem,
+) -> LpAffineExpression:
     """Calculate the dot product of two lists of linear expressions"""
-    if not _vector_like(v1) and not _vector_like(v2):
+
+    if isinstance(v1, (int, float)):
+        v1 = LpAffineExpression(v1)
+    if isinstance(v2, (int, float)):
+        v2 = LpAffineExpression(v2)
+
+    if isinstance(v1, (LpAffineExpression, LpVariable)) and isinstance(
+        v2, (LpAffineExpression, LpVariable)
+    ):
         return v1 * v2
-    elif not _vector_like(v1):
+    elif isinstance(v1, (LpAffineExpression, LpVariable, int, float)) and isinstance(
+        v2, Sequence
+    ):
         return lpDot([v1] * len(v2), v2)
-    elif not _vector_like(v2):
+    elif isinstance(v2, (LpAffineExpression, LpVariable, int, float)) and isinstance(
+        v1, Sequence
+    ):
         return lpDot(v1, [v2] * len(v1))
     else:
+        assert isinstance(v1, Sequence)
+        assert isinstance(v2, Sequence)
         return lpSum([lpDot(e1, e2) for e1, e2 in zip(v1, v2)])

--- a/pulp/sparse.py
+++ b/pulp/sparse.py
@@ -1,4 +1,4 @@
-from typing import Dict, Generic, List, Tuple, TypeVar, cast
+from typing import Generic, TypeVar
 
 # Sparse : Python basic dictionary sparse matrix
 
@@ -32,17 +32,17 @@ notably this allows the sparse matrix to be output in various formats
 T = TypeVar("T")
 
 
-class Matrix(Generic[T], Dict[Tuple[int, int], T]):
+class Matrix(Generic[T], dict[tuple[int, int], T]):
     """This is a dictionary based sparse matrix class"""
 
-    def __init__(self, rows: List[int], cols: List[int]):
+    def __init__(self, rows: list[int], cols: list[int]):
         """initialises the class by creating a matrix that will have the given
         rows and columns
         """
-        self.rows: List[int] = rows
-        self.cols: List[int] = cols
-        self.rowdict: Dict[int, Dict[int, T]] = {row: {} for row in rows}
-        self.coldict: Dict[int, Dict[int, T]] = {col: {} for col in cols}
+        self.rows: list[int] = rows
+        self.cols: list[int] = cols
+        self.rowdict: dict[int, dict[int, T]] = {row: {} for row in rows}
+        self.coldict: dict[int, dict[int, T]] = {col: {} for col in cols}
 
     def add(
         self,
@@ -54,7 +54,7 @@ class Matrix(Generic[T], Dict[Tuple[int, int], T]):
     ) -> None:
         if not rowcheck or row in self.rows:
             if not colcheck or col in self.cols:
-                dict.__setitem__(self, (row, col), item)
+                super().__setitem__((row, col), item)
                 self.rowdict[row][col] = item
                 self.coldict[col][row] = item
             else:
@@ -63,7 +63,7 @@ class Matrix(Generic[T], Dict[Tuple[int, int], T]):
         else:
             raise RuntimeError(f"row {row} is not in the matrix rows")
 
-    def addcol(self, col: int, rowitems: Dict[int, T]) -> None:
+    def addcol(self, col: int, rowitems: dict[int, T]) -> None:
         """adds a column"""
         if col in self.cols:
             for row, item in rowitems.items():
@@ -71,25 +71,18 @@ class Matrix(Generic[T], Dict[Tuple[int, int], T]):
         else:
             raise RuntimeError("col is not in the matrix columns")
 
-    def get(  # type: ignore[override]
-        self,
-        coords: Tuple[int, int],
-        default: T = 0,  # type: ignore[assignment]
-    ) -> T:
-        return dict.get(self, coords, default)
-
     def col_based_arrays(
         self,
-    ) -> Tuple[int, List[int], List[int], List[int], List[T]]:
+    ) -> tuple[int, list[int], list[int], list[int], list[T]]:
         numEls = len(self)
-        elemBase: List[T] = []
-        startsBase = []
-        indBase = []
-        lenBase = []
-        for i, col in enumerate(self.cols):
+        elemBase: list[T] = []
+        startsBase: list[int] = []
+        indBase: list[int] = []
+        lenBase: list[int] = []
+        for col in self.cols:
             startsBase.append(len(elemBase))
-            elemBase.extend(list(self.coldict[col].values()))
-            indBase.extend(list(self.coldict[col].keys()))
+            elemBase.extend(self.coldict[col].values())
+            indBase.extend(self.coldict[col].keys())
             lenBase.append(len(elemBase) - startsBase[-1])
 
         startsBase.append(len(elemBase))

--- a/pulp/tests/__init__.py
+++ b/pulp/tests/__init__.py
@@ -1,1 +1,1 @@
-from .run_tests import pulpTestAll
+from .run_tests import pulpTestAll  # type: ignore

--- a/pulp/tests/bin_packing_problem.py
+++ b/pulp/tests/bin_packing_problem.py
@@ -3,8 +3,8 @@ import random
 from itertools import product
 
 
-def _bin_packing_instance(bins, seed=0):
-    packed_bins = [[] for _ in range(bins)]
+def _bin_packing_instance(bins: int, seed: int | float | str | bytes | bytearray = 0):
+    packed_bins: list[list[int]] = [[] for _ in range(bins)]
     bin_size = bins * 100
     random.seed(seed)
     for i in range(len(packed_bins)):
@@ -21,8 +21,10 @@ def _bin_packing_instance(bins, seed=0):
     return items, packing, bin_size
 
 
-def create_bin_packing_problem(bins, seed=0):
-    items, packing, bin_size = _bin_packing_instance(bins=bins, seed=seed)
+def create_bin_packing_problem(
+    bins: int, seed: int | float | str | bytes | bytearray = 0
+):
+    items, _packing, bin_size = _bin_packing_instance(bins=bins, seed=seed)
 
     prob = LpProblem("bin_packing", LpMinimize)
 

--- a/pulp/tests/run_tests.py
+++ b/pulp/tests/run_tests.py
@@ -4,7 +4,7 @@ import pulp
 from pulp.tests import test_examples, test_gurobipy_env, test_pulp, test_sparse
 
 
-def pulpTestAll(test_docs=False):
+def pulpTestAll(test_docs: bool = False):
     all_solvers = pulp.listSolvers(onlyAvailable=False)
     available = pulp.listSolvers(onlyAvailable=True)
     print(f"Available solvers: {available}")

--- a/pulp/tests/test_examples.py
+++ b/pulp/tests/test_examples.py
@@ -5,7 +5,7 @@ import shutil
 
 
 class Examples_DocsTests(unittest.TestCase):
-    def test_examples(self, examples_dir="../../examples"):
+    def test_examples(self, examples_dir: str = "../../examples"):
         import importlib
 
         this_file = os.path.realpath(__file__)

--- a/pulp/tests/test_lpdot.py
+++ b/pulp/tests/test_lpdot.py
@@ -1,22 +1,32 @@
+import unittest
+import dataclasses
+
 from pulp import lpDot, LpVariable
 
 
-def test_lpdot():
-    x = LpVariable(name="x")
+class SparseTest(unittest.TestCase):
 
-    product = lpDot(1, 2 * x)
-    assert product.toDict() == [{"name": "x", "value": 2}]
+    def test_lpdot(self):
+        x = LpVariable(name="x")
+
+        product = lpDot(1, 2 * x)
+        assert [dataclasses.asdict(dc) for dc in product.toDataclass()] == [
+            {"name": "x", "value": 2}
+        ]
+
+    def test_pulp_002(self):
+        """
+        Test the lpDot operation
+        """
+        x = LpVariable("x")
+        y = LpVariable("y")
+        z = LpVariable("z")
+        a = [1, 2, 3]
+        assert dict(lpDot([x, y, z], a)) == {x: 1, y: 2, z: 3}
+        assert dict(lpDot([2 * x, 2 * y, 2 * z], a)) == {x: 2, y: 4, z: 6}
+        assert dict(lpDot([x + y, y + z, z], a)) == {x: 1, y: 3, z: 5}
+        assert dict(lpDot(a, [x + y, y + z, z])) == {x: 1, y: 3, z: 5}
 
 
-def test_pulp_002():
-    """
-    Test the lpDot operation
-    """
-    x = LpVariable("x")
-    y = LpVariable("y")
-    z = LpVariable("z")
-    a = [1, 2, 3]
-    assert dict(lpDot([x, y, z], a)) == {x: 1, y: 2, z: 3}
-    assert dict(lpDot([2 * x, 2 * y, 2 * z], a)) == {x: 2, y: 4, z: 6}
-    assert dict(lpDot([x + y, y + z, z], a)) == {x: 1, y: 3, z: 5}
-    assert dict(lpDot(a, [x + y, y + z, z])) == {x: 1, y: 3, z: 5}
+if __name__ == "__main__":
+    unittest.main()

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -8,7 +8,14 @@ import re
 import tempfile
 import unittest
 
-from pulp import LpConstraintVar, LpFractionConstraint, LpProblem, LpVariable
+from pulp import (
+    LpAffineExpression,
+    LpConstraint,
+    LpConstraintVar,
+    LpFractionConstraint,
+    LpProblem,
+    LpVariable,
+)
 from pulp import constants as const
 from pulp import lpSum
 from pulp.apis import *
@@ -1492,6 +1499,222 @@ class BaseSolverTest:
             a = math.nan
             x = LpVariable("x")
             self.assertRaises(PulpError, lambda: x * a)
+
+        def test_constraint_copy(self):
+            """
+            LpConstraint.copy()
+            """
+            x = LpVariable("x")
+            y = LpVariable("y")
+
+            expr: LpAffineExpression = x + y + 1
+            self.assertIsInstance(expr, LpAffineExpression)
+            self.assertEqual(expr.constant, 1)
+
+            c: LpConstraint = expr <= 5
+            self.assertIsInstance(c, LpConstraint)
+            self.assertEqual(c.constant, -4)
+            self.assertEqual(c.expr.constant, 1)
+
+            c2: LpConstraint = c.copy()
+            self.assertIsInstance(c2, LpConstraint)
+            self.assertEqual(c2.constant, -4)
+            self.assertEqual(c2.expr.constant, 1)
+            self.assertEqual(str(c), str(c2))
+            self.assertEqual(repr(c), repr(c2))
+
+        def test_constraint_add(self):
+            """
+            __add__ operator on LpConstraint
+            """
+            x = LpVariable("x")
+            y = LpVariable("y")
+
+            expr: LpAffineExpression = x + y + 1
+            self.assertIsInstance(expr, LpAffineExpression)
+            self.assertEqual(expr.constant, 1)
+
+            c1: LpConstraint = x + y <= 5
+            self.assertIsInstance(c1, LpConstraint)
+            self.assertEqual(c1.constant, -5)
+            self.assertEqual(c1.expr.constant, 0)
+            self.assertEqual(str(c1), "x + y <= 5")
+            self.assertEqual(repr(c1), "1*x + 1*y + -5 <= 0")
+
+            c1_int: LpConstraint = c1 + 2
+            self.assertIsInstance(c1_int, LpConstraint)
+            self.assertEqual(c1_int.constant, -3)
+            self.assertEqual(str(c1_int), "x + y <= 3")
+            self.assertEqual(repr(c1_int), "1*x + 1*y + -3 <= 0")
+
+            c1_variable: LpConstraint = c1 + x
+            self.assertIsInstance(c1_variable, LpConstraint)
+            self.assertEqual(str(c1_variable), str(2 * x + y <= 5))
+            self.assertEqual(repr(c1_variable), repr(2 * x + y <= 5))
+
+            expr: LpAffineExpression = x + 1
+            self.assertIsInstance(expr, LpAffineExpression)
+            self.assertEqual(expr.constant, 1)
+            self.assertEqual(str(expr), "x + 1")
+
+            c1_expr: LpConstraint = c1 + expr
+            self.assertIsInstance(c1_expr, LpConstraint)
+            self.assertEqual(c1_expr.expr.constant, 1)
+            self.assertEqual(c1_expr.constant, -4)
+            self.assertEqual(str(c1_expr), str(2 * x + y <= 4))
+            self.assertEqual(repr(c1_expr), repr(2 * x + y <= 4))
+
+            constraint: LpConstraint = x <= 1
+            self.assertIsInstance(constraint, LpConstraint)
+            c1_constraint: LpConstraint = c1 + constraint
+            self.assertEqual(str(c1_constraint), str(2 * x + y <= 6))
+            self.assertEqual(repr(c1_constraint), repr(2 * x + y <= 6))
+
+            constraint: LpConstraint = x + 1 <= 2
+            self.assertIsInstance(constraint, LpConstraint)
+            self.assertEqual(constraint.constant, -1)
+            self.assertEqual(constraint.expr.constant, 1)
+            c1_constraint: LpConstraint = c1 + constraint
+            self.assertEqual(str(c1_constraint), str(2 * x + y <= 6))
+            self.assertEqual(repr(c1_constraint), repr(2 * x + y <= 6))
+
+        def test_constraint_neg(self):
+            """
+            __neg__ operator on LpConstraint
+            """
+            x = LpVariable("x")
+            y = LpVariable("y")
+
+            c1: LpConstraint = x + y <= 5
+            self.assertIsInstance(c1, LpConstraint)
+            self.assertEqual(c1.constant, -5)
+
+            c1_neg: LpConstraint = -c1
+            self.assertIsInstance(c1_neg, LpConstraint)
+            self.assertEqual(c1_neg.constant, 5)
+            self.assertEqual(str(c1_neg), str(-x + -y <= -5))
+            self.assertEqual(repr(c1_neg), repr(-x + -y <= -5))
+
+        def test_constraint_sub(self):
+            """
+            __sub__ operator on LpConstraint
+            """
+            x = LpVariable("x")
+            y = LpVariable("y")
+
+            expr0: LpAffineExpression = 0 * x
+            self.assertIsInstance(expr0, LpAffineExpression)
+            self.assertTrue(expr0.isNumericalConstant())
+
+            c1: LpConstraint = x + y <= 5
+            self.assertIsInstance(c1, LpConstraint)
+            self.assertEqual(c1.constant, -5)
+
+            c1_int: LpConstraint = c1 - 2
+            self.assertIsInstance(c1_int, LpConstraint)
+            self.assertEqual(c1_int.constant, -7)
+
+            c1_variable: LpConstraint = c1 - x
+            self.assertIsInstance(c1_variable, LpConstraint)
+            self.assertEqual(str(c1_variable), "0*x + y <= 5")
+            self.assertEqual(repr(c1_variable), "0*x + 1*y + -5 <= 0")
+
+            expr: LpAffineExpression = x + 1
+            self.assertIsInstance(expr, LpAffineExpression)
+            c1_expr: LpConstraint = c1 - expr
+            self.assertIsInstance(c1_expr, LpConstraint)
+            self.assertEqual(str(c1_expr), "0*x + y <= 6")
+            self.assertEqual(repr(c1_expr), "0*x + 1*y + -6 <= 0")
+
+            constraint: LpConstraint = x <= 1
+            self.assertIsInstance(constraint, LpConstraint)
+            c1_constraint: LpConstraint = c1 - constraint
+            self.assertEqual(str(c1_constraint), "0*x + y <= 4")
+            self.assertEqual(repr(c1_constraint), "0*x + 1*y + -4 <= 0")
+
+            constraint: LpConstraint = x + 1 <= 2
+            self.assertIsInstance(constraint, LpConstraint)
+            c1_constraint: LpConstraint = c1 - constraint
+            self.assertEqual(str(c1_constraint), "0*x + y <= 4")
+            self.assertEqual(repr(c1_constraint), "0*x + 1*y + -4 <= 0")
+
+        def test_constraint_mul(self):
+            """
+            __mul__ operator on LpConstraint
+            """
+            x = LpVariable("x")
+            y = LpVariable("y")
+
+            c1: LpConstraint = x + y <= 5
+            self.assertIsInstance(c1, LpConstraint)
+            self.assertEqual(c1.constant, -5)
+
+            c2: LpConstraint = y <= 5
+            self.assertIsInstance(c2, LpConstraint)
+            self.assertEqual(c2.constant, -5)
+
+            c1_int: LpConstraint = c1 * 2
+            self.assertIsInstance(c1_int, LpConstraint)
+            self.assertEqual(c1_int.constant, -10)
+            self.assertEqual(str(c1_int), "2*x + 2*y <= 10")
+            self.assertEqual(repr(c1_int), "2*x + 2*y + -10 <= 0")
+
+            c1_const_expr: LpConstraint = c1 * LpAffineExpression(2)
+            self.assertIsInstance(c1_const_expr, LpConstraint)
+            self.assertEqual(c1_const_expr.constant, -10)
+            self.assertEqual(str(c1_int), "2*x + 2*y <= 10")
+            self.assertEqual(repr(c1_int), "2*x + 2*y + -10 <= 0")
+
+            with self.assertRaises(TypeError):
+                c1 * x
+
+            with self.assertRaises(TypeError):
+                c2 * x
+
+            with self.assertRaises(TypeError):
+                c1 * (x + 1)
+
+            with self.assertRaises(TypeError):
+                c2 * (x + 1)
+
+        def test_constraint_div(self):
+            """
+            __div__ operator on LpConstraint
+            """
+            x = LpVariable("x")
+            y = LpVariable("y")
+
+            c1: LpConstraint = x + y <= 5
+            self.assertIsInstance(c1, LpConstraint)
+            self.assertEqual(c1.constant, -5)
+
+            c2: LpConstraint = y <= 5
+            self.assertIsInstance(c2, LpConstraint)
+            self.assertEqual(c2.constant, -5)
+
+            c1_int: LpConstraint = c1 / 2.0
+            self.assertIsInstance(c1_int, LpConstraint)
+            self.assertEqual(c1_int.constant, -2.5)
+            self.assertEqual(str(c1_int), "0.5*x + 0.5*y <= 2.5")
+            self.assertEqual(repr(c1_int), "0.5*x + 0.5*y + -2.5 <= 0")
+
+            c1_const_expr: LpConstraint = c1 / LpAffineExpression(2)
+            self.assertIsInstance(c1_const_expr, LpConstraint)
+            self.assertEqual(c1_const_expr.constant, -2.5)
+            self.assertEqual(str(c1_const_expr), "0.5*x + 0.5*y <= 2.5")
+            self.assertEqual(repr(c1_const_expr), "0.5*x + 0.5*y + -2.5 <= 0")
+
+            with self.assertRaises(TypeError):
+                c1 / x
+
+            with self.assertRaises(TypeError):
+                c2 / x
+
+            with self.assertRaises(TypeError):
+                c1 / (x + 1)
+
+            with self.assertRaises(TypeError):
+                c2 / (x + 1)
 
 
 class PULP_CBC_CMDTest(BaseSolverTest.PuLPTest):

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -1719,25 +1719,25 @@ class BaseSolverTest:
         def test_regression_794(self):
             # See: https://github.com/coin-or/pulp/issues/794#issuecomment-2671682768
 
-            initial_stock = 8 # s_0
-            demands = [5, 4, 8, 10, 4, 2, 1] # demands[t] = d_t
-            max_periods = len(demands) - 1 # T
+            initial_stock = 8  # s_0
+            demands = [5, 4, 8, 10, 4, 2, 1]  # demands[t] = d_t
+            max_periods = len(demands) - 1  # T
 
             # Create decision variables.
             supply: list[LpVariable] = []  # supply[t] = x_t
             for t in range(1, max_periods + 1):
-                variable = LpVariable(f'x_{t}', cat='Integer', lowBound=0)
+                variable = LpVariable(f"x_{t}", cat="Integer", lowBound=0)
                 supply.append(variable)
 
-            stock: list[LpVariable | int] = [initial_stock] # stock[t] = s_t
+            stock: list[LpVariable | int] = [initial_stock]  # stock[t] = s_t
             for t in range(1, max_periods + 1):
-                variable = LpVariable(f's_{t}', cat='Integer', lowBound=0)
+                variable = LpVariable(f"s_{t}", cat="Integer", lowBound=0)
                 stock.append(variable)
 
             # Create the constraints.
             for t in range(1, max_periods + 1):
                 lhs = stock[t]
-                rhs = stock[t-1] + supply[t-1] - demands[t-1]
+                rhs = stock[t - 1] + supply[t - 1] - demands[t - 1]
                 expr = lhs == rhs
 
                 self.assertIsInstance(lhs, LpVariable)
@@ -1753,6 +1753,7 @@ class BaseSolverTest:
                 else:
                     self.assertEqual(str(rhs), f"s_{t-1} + x_{t} - {demands[t-1]}")
                     self.assertEqual(expr.constant, -rhs.constant)
+
 
 class PULP_CBC_CMDTest(BaseSolverTest.PuLPTest):
     solveInst = PULP_CBC_CMD

--- a/pulp/tests/test_sparse.py
+++ b/pulp/tests/test_sparse.py
@@ -53,3 +53,7 @@ class SparseTest(unittest.TestCase):
             [2, 1, 2],
             [9.876, 1.234, 5.678],
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pulp/utilities.py
+++ b/pulp/utilities.py
@@ -5,14 +5,14 @@ import collections
 import itertools
 from itertools import combinations as combination
 from itertools import permutations as permutation
-from typing import TypeVar, TYPE_CHECKING, Any, Sequence, Callable, Mapping
+from typing import TypeVar, TYPE_CHECKING, Any, Sequence, Callable, Mapping, overload
 
 T = TypeVar("T")
 K = TypeVar("K")
 V = TypeVar("V")
 
 if TYPE_CHECKING:
-    from pulp.pulp import LptNumber, LptExpr
+    from pulp.pulp import LptNumber, LptExpr, LpVariable, LpAffineExpression
 
 
 def resource_clock():
@@ -25,6 +25,17 @@ def isNumber(x: Any) -> bool:
     """Returns true if x is an int or a float"""
     return isinstance(x, (int, float))
 
+@overload
+def value(x: None) -> None: ...
+
+@overload
+def value(x: int) -> int: ...
+
+@overload
+def value(x: float) -> float: ...
+
+@overload
+def value(x: LpVariable | LpAffineExpression) -> LptNumber | None: ...
 
 def value(x: LptExpr | None) -> LptNumber | None:
     """Returns the value of the variable/expression x, or x if it is a number"""

--- a/pulp/utilities.py
+++ b/pulp/utilities.py
@@ -1,8 +1,14 @@
 # Utility functions
+from __future__ import annotations
+
 import collections
 import itertools
 from itertools import combinations as combination
 from itertools import permutations as permutation
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pulp.pulp import LpVariable, LpAffineExpression, LpConstraint, LpConstraintVar
 
 
 def resource_clock():
@@ -11,24 +17,28 @@ def resource_clock():
     return resource.getrusage(resource.RUSAGE_CHILDREN).ru_utime
 
 
-def isNumber(x):
+def isNumber(x) -> bool:
     """Returns true if x is an int or a float"""
     return isinstance(x, (int, float))
 
 
-def value(x):
+def value(
+    x: int | float | LpVariable | LpAffineExpression | LpConstraint | LpConstraintVar,
+) -> int | float | None:
     """Returns the value of the variable/expression x, or x if it is a number"""
-    if isNumber(x):
+    if isinstance(x, (int, float)):
         return x
     else:
         return x.value()
 
 
-def valueOrDefault(x):
+def valueOrDefault(
+    x: int | float | LpVariable | LpAffineExpression | LpConstraint,
+) -> int | float:
     """Returns the value of the variable/expression x, or x if it is a number
     Variable without value (None) are affected a possible value (within their
     bounds)."""
-    if isNumber(x):
+    if isinstance(x, (int, float)):
         return x
     else:
         return x.valueOrDefault()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "Programming Language :: Python",
         "Topic :: Scientific/Engineering :: Mathematics",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     # need the cbc directories here as the executable bit is set
     packages=[
         "pulp",


### PR DESCRIPTION
I have seen #755 and wanted to take a look at providing type hints also. I would appreciate a review of this, as there are some choices I made which need to be checked and others where a decision needs to be made.

Summary:
- Increases minimum version to Python 3.9, as this is when hinting `list[T]` was introduced (instead of using `List[T]`)
- Added Lpt* type aliases to avoid excessive Unions across the code
- Overloads for dict, dicts and matrix
- Most of the examples type check successfully
- Removed LpElement
- Needed to move away from dicts to dataclasses to serialise MPS. Ability to convert to dicts is provided by Python, but a separate package (dacite) has been needed to load from json into the dataclasses.
- Removed the ability for `LpAffineExpression to inherit from an OrderedDict, always inherit from dict.

Choices to make:
1. What type should be used to store coefficients? Currently a mixture of int and float is allowed.
2. dicts and matrix cannot be fully typed with Python's type hints. I have added overloads for 3 dimensional inputs, how many is appropriate?
3. What is `LpConstraintVar`? Is it a variable or is it a constraint? There are several pieces of code in `LpAffineExpression` that assume that all the items it contains are either a `LpVariable` or a `LpConstraintVar`. Several options:
    - Could `LpConstraintVar` inherit from `LpVariable`?
    - Manage dict of `LpConstraintVar` separately?
    - Does `LpConstraintVar` support operators in a `LpAffineExpression`?
4. There seems to be a number of problems with `FractionElasticSubProblem` as parameters seemed to be in the incorrect order for the `__init__`.

There is also a test failure to investigate (PULP_CBC_CMDTest.test_dual_variables_reduced_costs), but I am having trouble finding the root cause.