### PR TITLE
Avoid memory cost of saving initial lower and upper bounds if not fixing the value of a variable

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -286,14 +286,14 @@ class LpVariable(LpElement):
         self, name, lowBound=None, upBound=None, cat=const.LpContinuous, e=None
     ):
         LpElement.__init__(self, name)
-        self._lowbound_original = self.lowBound = lowBound
-        self._upbound_original = self.upBound = upBound
+        self.lowBound = lowBound
+        self.upBound = upBound
         self.cat = cat
         self.varValue = None
         self.dj = None
         if cat == const.LpBinary:
-            self._lowbound_original = self.lowBound = 0
-            self._upbound_original = self.upBound = 1
+            self.lowBound = 0
+            self.upBound = 1
             self.cat = const.LpInteger
         # Code to add a variable to constraints for column based
         # modelling.
@@ -652,6 +652,8 @@ class LpVariable(LpElement):
         """
         val = self.varValue
         if val is not None:
+            self._lowbound_original = self.lowBound
+            self._upbound_original = self.upBound
             self.bounds(val, val)
 
     def isFixed(self):
@@ -663,8 +665,13 @@ class LpVariable(LpElement):
         return self.isConstant()
 
     def unfixValue(self):
+        if not hasattr(self, "_lowbound_original") or not hasattr(self, "_upbound_original"):
+            raise RuntimeError("The value must first be fixed before it can be unfixed")
+
         self.bounds(self._lowbound_original, self._upbound_original)
 
+        del self._lowbound_original
+        del self._upbound_original
 
 class LpAffineExpression(_DICT_TYPE):
     """

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -665,13 +665,16 @@ class LpVariable(LpElement):
         return self.isConstant()
 
     def unfixValue(self):
-        if not hasattr(self, "_lowbound_original") or not hasattr(self, "_upbound_original"):
+        if not hasattr(self, "_lowbound_original") or not hasattr(
+            self, "_upbound_original"
+        ):
             raise RuntimeError("The value must first be fixed before it can be unfixed")
 
         self.bounds(self._lowbound_original, self._upbound_original)
 
         del self._lowbound_original
         del self._upbound_original
+
 
 class LpAffineExpression(_DICT_TYPE):
     """

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -504,6 +504,39 @@ class BaseSolverTest:
             self.solver.optionsDict["warmStart"] = True
             pulpTestCheck(prob, self.solver, [const.LpStatusOptimal], solution)
 
+            # Check values can be unfixed
+            for v in [x, y, z]:
+                v.unfixValue()
+
+            self.assertEqual(x.lowBound, 0)
+            self.assertEqual(x.upBound, 4)
+
+            self.assertEqual(y.lowBound, -1)
+            self.assertEqual(y.upBound, 1)
+
+            self.assertEqual(z.lowBound, 0)
+            self.assertEqual(z.upBound, None)
+
+            # Cannot unfix again
+            with self.assertRaises(RuntimeError):
+                x.unfixValue()
+            with self.assertRaises(RuntimeError):
+                y.unfixValue()
+            with self.assertRaises(RuntimeError):
+                z.unfixValue()
+
+        def test_unfix_value_error(self):
+            x = LpVariable("x", 0, 4)
+            y = LpVariable("y", -1, 1)
+            z = LpVariable("z", 0, None, const.LpInteger)
+
+            with self.assertRaises(RuntimeError):
+                x.unfixValue()
+            with self.assertRaises(RuntimeError):
+                y.unfixValue()
+            with self.assertRaises(RuntimeError):
+                z.unfixValue()
+
         def test_relaxed_mip(self):
             prob = LpProblem(self._testMethodName, const.LpMinimize)
             x = LpVariable("x", 0, 4)


### PR DESCRIPTION
Continuing the theme of performance improvements, I have a model with a large number of variables (~4 million) which leads to high RAM usage when instantiating those variables.

`LpVariable` currently stores copies of the initial upper and lower bounds when instantiated. This is a cost that users need to pay even if they are not fixing/unfixing variables.

This change instead stores the original bounds when fixing instead. So the memory cost is paid only when fixing/unfixing variables.