### PR TITLE
Fixes rounding error in GLPK_CMD api #814

### DIFF
--- a/pulp/apis/glpk_api.py
+++ b/pulp/apis/glpk_api.py
@@ -118,9 +118,9 @@ class GLPK_CMD(LpSolver_CMD):
 
         status, values = self.readsol(tmpOut, tmpSol)
 
-        vars = dict([(var.name,var) for var in lp.variables()])
-        for name,value in values.items():
-            if name not in vars: # __dummy
+        vars = dict([(var.name, var) for var in lp.variables()])
+        for name, value in values.items():
+            if name not in vars:  # __dummy
                 continue
             var = vars[name]
             if var.cat == constants.LpInteger and self.mip:
@@ -188,25 +188,26 @@ class GLPK_CMD(LpSolver_CMD):
             while True:
                 ln = f.readline()
                 elems = ln.split()
-                if elems[0] == 'c':
+                if elems[0] == "c":
                     continue
-                if elems[0] == 'e':
+                if elems[0] == "e":
                     break
-                if elems[0] == 'j':
+                if elems[0] == "j":
                     values.append(elems[vpos])
-                if elems[0] == 's':
-                    status2 = {'o': constants.LpStatusOptimal,
-                               'f': constants.LpStatusOptimal,
-                               'n': constants.LpStatusInfeasible,
-                               'u': constants.LpStatusUndefined
-                               }[elems[4]]
-                    vpos = {'mip': 2, 'bas': 3, 'ipt': 2}[elems[1]]
+                if elems[0] == "s":
+                    status2 = {
+                        "o": constants.LpStatusOptimal,
+                        "f": constants.LpStatusOptimal,
+                        "n": constants.LpStatusInfeasible,
+                        "u": constants.LpStatusUndefined,
+                    }[elems[4]]
+                    vpos = {"mip": 2, "bas": 3, "ipt": 2}[elems[1]]
 
             values = dict(zip(names, values))
 
             assert status == status2
 
-            return status,values
+            return status, values
 
 
 GLPK = GLPK_CMD

--- a/pulp/apis/glpk_api.py
+++ b/pulp/apis/glpk_api.py
@@ -75,9 +75,9 @@ class GLPK_CMD(LpSolver_CMD):
         """Solve a well formulated lp problem"""
         if not self.executable(self.path):
             raise PulpSolverError("PuLP: cannot execute " + self.path)
-        tmpLp, tmpSol = self.create_tmp_files(lp.name, "lp", "sol")
+        tmpLp, tmpOut, tmpSol = self.create_tmp_files(lp.name, "lp", "out", "sol")
         lp.writeLP(tmpLp, writeSOS=0)
-        proc = ["glpsol", "--cpxlp", tmpLp, "-o", tmpSol]
+        proc = ["glpsol", "--cpxlp", tmpLp, "-o", tmpOut, "-w", tmpSol]
         if self.timeLimit:
             proc.extend(["--tmlim", str(self.timeLimit)])
         if not self.mip:
@@ -115,15 +115,29 @@ class GLPK_CMD(LpSolver_CMD):
 
         if not os.path.exists(tmpSol):
             raise PulpSolverError("PuLP: Error while executing " + self.path)
-        status, values = self.readsol(tmpSol)
+
+        status, values = self.readsol(tmpOut, tmpSol)
+
+        vars = dict([(var.name,var) for var in lp.variables()])
+        for name,value in values.items():
+            if name not in vars: # __dummy
+                continue
+            var = vars[name]
+            if var.cat == constants.LpInteger and self.mip:
+                values[name] = int(value)
+            else:
+                values[name] = float(value)
+
         lp.assignVarsVals(values)
         lp.assignStatus(status)
         self.delete_tmp_files(tmpLp, tmpSol)
         return status
 
-    def readsol(self, filename):
-        """Read a GLPK solution file"""
-        with open(filename) as f:
+    def readsol(self, outFile, solFile):
+        """Read GLPK solution files"""
+
+        # first determine status and column names
+        with open(outFile) as f:
             f.readline()
             rows = int(f.readline().split()[1])
             cols = int(f.readline().split()[1])
@@ -148,7 +162,7 @@ class GLPK_CMD(LpSolver_CMD):
                 "INTEGER UNDEFINED",
                 "INTEGER EMPTY",
             ]
-            values = {}
+            names = []
             for i in range(4):
                 f.readline()
             for i in range(rows):
@@ -161,16 +175,38 @@ class GLPK_CMD(LpSolver_CMD):
                 line = f.readline().split()
                 name = line[1]
                 if len(line) == 2:
-                    line = [0, 0] + f.readline().split()
-                if isInteger:
-                    if line[2] == "*":
-                        value = int(float(line[3]))
-                    else:
-                        value = float(line[2])
-                else:
-                    value = float(line[3])
-                values[name] = value
-        return status, values
+                    f.readline()
+                names.append(name)
+
+        # now actually read column values
+        with open(solFile) as f:
+
+            values = []
+            status2 = constants.LpStatusUndefined
+            vpos = 2
+
+            while True:
+                ln = f.readline()
+                elems = ln.split()
+                if elems[0] == 'c':
+                    continue
+                if elems[0] == 'e':
+                    break
+                if elems[0] == 'j':
+                    values.append(elems[vpos])
+                if elems[0] == 's':
+                    status2 = {'o': constants.LpStatusOptimal,
+                               'f': constants.LpStatusOptimal,
+                               'n': constants.LpStatusInfeasible,
+                               'u': constants.LpStatusUndefined
+                               }[elems[4]]
+                    vpos = {'mip': 2, 'bas': 3, 'ipt': 2}[elems[1]]
+
+            values = dict(zip(names, values))
+
+            assert status == status2
+
+            return status,values
 
 
 GLPK = GLPK_CMD

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -2026,11 +2026,11 @@ class GLPK_CMDTest(BaseSolverTest.PuLPTest):
         # see pulp.py asCplexLpVariable / asCplexLpConstraint methods
         ub = 999999999999
 
-        assert int(format(ub, '.12g')) == ub
-        assert float(format(ub+2, '.12g')) != float(ub+2)
+        assert int(format(ub, ".12g")) == ub
+        assert float(format(ub + 2, ".12g")) != float(ub + 2)
 
-        model = LpProblem('mip-814', LpMaximize)
-        Q = LpVariable('Q', cat='Integer', lowBound=0, upBound=ub)
+        model = LpProblem("mip-814", LpMaximize)
+        Q = LpVariable("Q", cat="Integer", lowBound=0, upBound=ub)
         model += Q
         model += Q >= 0
         model.solve(self.solver)
@@ -2041,15 +2041,15 @@ class GLPK_CMDTest(BaseSolverTest.PuLPTest):
         Test there is no rounding issue for LP (simplex method) problems as described in #814
         """
         ub = 999999999999.0
-        assert float(format(ub, '.12g')) == ub
-        assert float(format(ub+0.1, '.12g')) != ub+0.1
+        assert float(format(ub, ".12g")) == ub
+        assert float(format(ub + 0.1, ".12g")) != ub + 0.1
 
-        for simplex in ['primal', 'dual']:
-            model = LpProblem(f'lp-814-{simplex}', LpMaximize)
-            Q = LpVariable('Q', lowBound=0, upBound=ub)
+        for simplex in ["primal", "dual"]:
+            model = LpProblem(f"lp-814-{simplex}", LpMaximize)
+            Q = LpVariable("Q", lowBound=0, upBound=ub)
             model += Q
             model += Q >= 0
-            self.solver.options.append('--'+simplex)
+            self.solver.options.append("--" + simplex)
             model.solve(self.solver)
             self.solver.options = self.solver.options[:-1]
             assert Q.value() == ub
@@ -2061,14 +2061,14 @@ class GLPK_CMDTest(BaseSolverTest.PuLPTest):
         # this one is limited by GLPK int pt feasibility, not formatting
         ub = 12345678999.0
 
-        model = LpProblem('ipt-814', LpMaximize)
-        Q = LpVariable('Q', lowBound=0, upBound=ub)
+        model = LpProblem("ipt-814", LpMaximize)
+        Q = LpVariable("Q", lowBound=0, upBound=ub)
         model += Q
         model += Q >= 0
-        self.solver.options.append('--interior')
+        self.solver.options.append("--interior")
         model.solve(self.solver)
         self.solver.options = self.solver.options[:-1]
-        assert abs(Q.value() - ub)/ub < 1e-9
+        assert abs(Q.value() - ub) / ub < 1e-9
 
 
 class GUROBITest(BaseSolverTest.PuLPTest):


### PR DESCRIPTION
As described in #814 this PR implements reading column values from '--write' solution file instead of '--output'.

Alas it was not possible to get rid of '--output' file as `glpsol` provides no other means to determine column names.

Note 1, this could be a breaking change for some users

Note 2, there is still some precision limit as the original '.lp' file is being formatted with '.12g' specifier.
See e.g. [asCplexLpVariable](https://github.com/coin-or/pulp/blob/79f7146e3580baa3a4cf0e9e90b2129bd3622686/pulp/pulp.py#L575-L591) or [asCplexLpConstraint](https://github.com/coin-or/pulp/blob/79f7146e3580baa3a4cf0e9e90b2129bd3622686/pulp/pulp.py#L1098-L1116)