### PR TITLE
Remove Python 2 compatibility

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -141,11 +141,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-try:  # allow Python 2/3 compatibility
-    maketrans = str.maketrans
-except AttributeError:
-    from string import maketrans  # type: ignore[attr-defined,no-redef]
-
 _DICT_TYPE = dict
 
 if sys.platform not in ["cli"]:
@@ -178,7 +173,7 @@ class LpElement:
     # To remove illegal characters from the names
     illegal_chars = "-+[] ->/"
     expression = re.compile(f"[{re.escape(illegal_chars)}]")
-    trans = maketrans(illegal_chars, "________")
+    trans = str.maketrans(illegal_chars, "________")
 
     def setName(self, name):
         if name:
@@ -690,7 +685,7 @@ class LpAffineExpression(_DICT_TYPE):
     """
 
     # to remove illegal characters from the names
-    trans = maketrans("-+[] ", "_____")
+    trans = str.maketrans("-+[] ", "_____")
 
     @property
     def name(self) -> str | None:


### PR DESCRIPTION
As Python 2 is not supported, there is no need for maintaining compatibility with it.