### PR TITLE
Use dict as the ordered dict type

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -146,24 +146,6 @@ try:  # allow Python 2/3 compatibility
 except AttributeError:
     from string import maketrans  # type: ignore[attr-defined,no-redef]
 
-_DICT_TYPE = dict
-
-if sys.platform not in ["cli"]:
-    # iron python does not like an OrderedDict
-    try:
-        from odict import OrderedDict  # type: ignore[import-not-found]
-
-        _DICT_TYPE = OrderedDict  # type: ignore[misc]
-    except ImportError:
-        pass
-    try:
-        # python 2.7 or 3.1
-        from collections import OrderedDict
-
-        _DICT_TYPE = OrderedDict  # type: ignore[misc]
-    except ImportError:
-        pass
-
 try:
     import ujson as json  # type: ignore[import-untyped]
 except ImportError:
@@ -666,7 +648,7 @@ class LpVariable(LpElement):
         self.bounds(self._lowbound_original, self._upbound_original)
 
 
-class LpAffineExpression(_DICT_TYPE):
+class LpAffineExpression(dict):
     """
     A linear combination of :class:`LpVariables<LpVariable>`.
     Can be initialised with the following:
@@ -1424,7 +1406,7 @@ class LpProblem:
             warnings.warn("Spaces are not permitted in the name. Converted to '_'")
             name = name.replace(" ", "_")
         self.objective: None | LpAffineExpression = None  # type: ignore[annotation-unchecked]
-        self.constraints: dict[str, LpConstraint] = _DICT_TYPE()  # type: ignore[annotation-unchecked]
+        self.constraints: dict[str, LpConstraint] = {}  # type: ignore[annotation-unchecked]
         self.name = name
         self.sense = sense
         self.sos1 = {}
@@ -1492,7 +1474,7 @@ class LpProblem:
         lpcopy = LpProblem(name=self.name, sense=self.sense)
         if self.objective is not None:
             lpcopy.objective = self.objective.copy()
-        lpcopy.constraints = _DICT_TYPE[str, LpConstraint]()
+        lpcopy.constraints = {}
         for k, v in self.constraints.items():
             lpcopy.constraints[k] = v.copy()
         lpcopy.sos1 = self.sos1.copy()


### PR DESCRIPTION
The latest version of [IronPython ](https://ironpython.net/) is 3.4 and since Python 3.6 dict has maintained insertion order and this change has been [guaranteed ](https://mail.python.org/pipermail/python-dev/2017-December/151283.html) since 3.7.

So remove compatibility code and just use dict.