### PR TITLE
Add __truediv__ to LpVariable and remove __div__ and __rdiv__ as they are not supported in Python 3

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -235,11 +235,8 @@ class LpElement:
     def __rmul__(self, other):
         return LpAffineExpression(self) * other
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         return LpAffineExpression(self) / other
-
-    def __rdiv__(self, other):
-        raise TypeError("Expressions cannot be divided by a variable")
 
     def __le__(self, other):
         return LpAffineExpression(self) <= other
@@ -978,7 +975,7 @@ class LpAffineExpression(_DICT_TYPE):
     def __rmul__(self, other):
         return self * other
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         if isinstance(other, (LpAffineExpression, LpConstraint)) or isinstance(
             other, LpVariable
         ):
@@ -993,26 +990,6 @@ class LpAffineExpression(_DICT_TYPE):
         e.constant = self.constant / other
         for v, x in self.items():
             e[v] = x / other
-        return e
-
-    def __truediv__(self, other):
-        return self.__div__(other)
-
-    def __rdiv__(self, other):
-        e = self.emptyCopy()
-        if len(self):
-            raise TypeError(
-                "Expressions cannot be divided by a non-constant expression"
-            )
-        c = self.constant
-        if isinstance(other, (LpAffineExpression, LpConstraint)):
-            e.constant = other.constant / c
-            for v, x in other.items():
-                e[v] = x / c
-        elif not math.isfinite(other):
-            raise const.PulpError("Cannot divide variables with NaN/inf values")
-        else:
-            e.constant = other / c
         return e
 
     def __le__(self, other) -> LpConstraint:

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -1737,6 +1737,17 @@ class BaseSolverTest:
             with self.assertRaises(TypeError):
                 c2 / (x + 1)
 
+        def test_variable_div(self):
+            """
+            __div__ operator on LpVariable
+            """
+            x = LpVariable("x")
+            x_div = x / 2
+            self.assertIsInstance(x_div, LpAffineExpression)
+            self.assertEqual(x_div[x], 0.5)
+
+            self.assertEqual(str(x_div), "0.5*x")
+
         def test_regression_794(self):
             # See: https://github.com/coin-or/pulp/issues/794#issuecomment-2671682768
 


### PR DESCRIPTION
For #826.

`__div__` and `__rdiv__` are Python 2 features, so I have removed them.
