### PR TITLE
Rewrite MPS parsing to use dataclasses instead of dicts

### DIFF
--- a/pulp/mps_lp.py
+++ b/pulp/mps_lp.py
@@ -397,8 +397,6 @@ def writeLP(
     mip: bool = True,
     max_length: int = 100,
 ):
-    if lp.objective is None:
-        raise ValueError("objective is None")
     f = open(filename, "w")
     f.write("\\* " + lp.name + " *\\\n")
     if lp.sense == 1:
@@ -406,6 +404,7 @@ def writeLP(
     else:
         f.write("Maximize\n")
     wasNone, objectiveDummyVar = lp.fixObjective()
+    assert lp.objective is not None
     objName = lp.objective.name
     if not objName:
         objName = "OBJ"

--- a/pulp/mps_lp.py
+++ b/pulp/mps_lp.py
@@ -41,10 +41,13 @@ class MPSParameters:
 
     @classmethod
     def fromDict(cls, data: dict[str, Any]) -> MPSParameters:
-        return cls(str(data["name"]),
-                   int(data["sense"]),
-                   int(data["status"]),
-                   int(data["sol_status"]))
+        return cls(
+            str(data["name"]),
+            int(data["sense"]),
+            int(data["status"]),
+            int(data["sol_status"]),
+        )
+
 
 @dataclass
 class MPSCoefficient:
@@ -53,8 +56,7 @@ class MPSCoefficient:
 
     @classmethod
     def fromDict(cls, data: dict[str, Any]) -> MPSCoefficient:
-        return cls(data["name"],
-                   float(data["value"]))
+        return cls(data["name"], float(data["value"]))
 
 
 @dataclass
@@ -64,8 +66,10 @@ class MPSObjective:
 
     @classmethod
     def fromDict(cls, data: dict[str, Any]) -> MPSObjective:
-        return cls(data["name"],
-                   [MPSCoefficient.fromDict(d) for d in data["coefficients"]])
+        return cls(
+            data["name"], [MPSCoefficient.fromDict(d) for d in data["coefficients"]]
+        )
+
 
 @dataclass
 class MPSVariable:
@@ -78,12 +82,15 @@ class MPSVariable:
 
     @classmethod
     def fromDict(cls, data: dict[str, Any]) -> MPSVariable:
-        return cls(data["name"],
-                   data["cat"],
-                   data.get("lowBound", 0),
-                   data.get("upBound", None),
-                   data.get("varValue", None),
-                   data.get("dj", None))
+        return cls(
+            data["name"],
+            data["cat"],
+            data.get("lowBound", 0),
+            data.get("upBound", None),
+            data.get("varValue", None),
+            data.get("dj", None),
+        )
+
 
 @dataclass
 class MPSConstraint:
@@ -95,11 +102,14 @@ class MPSConstraint:
 
     @classmethod
     def fromDict(cls, data: dict[str, Any]) -> MPSConstraint:
-        return cls(data.get("name", None),
-                   data["sense"],
-                   [MPSCoefficient.fromDict(d) for d in data["coefficients"]],
-                   data.get("pi", None),
-                   data.get("constant", 0))
+        return cls(
+            data.get("name", None),
+            data["sense"],
+            [MPSCoefficient.fromDict(d) for d in data["coefficients"]],
+            data.get("pi", None),
+            data.get("constant", 0),
+        )
+
 
 @dataclass
 class MPS:
@@ -112,12 +122,14 @@ class MPS:
 
     @classmethod
     def fromDict(cls, data: dict[str, Any]) -> MPS:
-        return cls(MPSParameters.fromDict(data["parameters"]),
-                   MPSObjective.fromDict(data["objective"]),
-                   [MPSVariable.fromDict(d) for d in data["variables"]],
-                   [MPSConstraint.fromDict(d) for d in data["constraints"]],
-                   data["sos1"],
-                   data["sos2"])
+        return cls(
+            MPSParameters.fromDict(data["parameters"]),
+            MPSObjective.fromDict(data["objective"]),
+            [MPSVariable.fromDict(d) for d in data["variables"]],
+            [MPSConstraint.fromDict(d) for d in data["constraints"]],
+            data["sos1"],
+            data["sos2"],
+        )
 
 
 def readMPS(path: str, sense: int, dropConsNames: bool = False) -> MPS:

--- a/pulp/mps_lp.py
+++ b/pulp/mps_lp.py
@@ -39,11 +39,22 @@ class MPSParameters:
     status: int
     sol_status: int
 
+    @classmethod
+    def fromDict(cls, data: dict[str, Any]) -> MPSParameters:
+        return cls(str(data["name"]),
+                   int(data["sense"]),
+                   int(data["status"]),
+                   int(data["sol_status"]))
 
 @dataclass
 class MPSCoefficient:
     name: str
     value: float
+
+    @classmethod
+    def fromDict(cls, data: dict[str, Any]) -> MPSCoefficient:
+        return cls(data["name"],
+                   float(data["value"]))
 
 
 @dataclass
@@ -51,6 +62,10 @@ class MPSObjective:
     name: str | None
     coefficients: list[MPSCoefficient]
 
+    @classmethod
+    def fromDict(cls, data: dict[str, Any]) -> MPSObjective:
+        return cls(data["name"],
+                   [MPSCoefficient.fromDict(d) for d in data["coefficients"]])
 
 @dataclass
 class MPSVariable:
@@ -61,6 +76,14 @@ class MPSVariable:
     varValue: float | None = None
     dj: float | None = None
 
+    @classmethod
+    def fromDict(cls, data: dict[str, Any]) -> MPSVariable:
+        return cls(data["name"],
+                   data["cat"],
+                   data.get("lowBound", 0),
+                   data.get("upBound", None),
+                   data.get("varValue", None),
+                   data.get("dj", None))
 
 @dataclass
 class MPSConstraint:
@@ -70,6 +93,13 @@ class MPSConstraint:
     pi: float | None = None
     constant: float = 0
 
+    @classmethod
+    def fromDict(cls, data: dict[str, Any]) -> MPSConstraint:
+        return cls(data.get("name", None),
+                   data["sense"],
+                   [MPSCoefficient.fromDict(d) for d in data["coefficients"]],
+                   data.get("pi", None),
+                   data.get("constant", 0))
 
 @dataclass
 class MPS:
@@ -79,6 +109,15 @@ class MPS:
     constraints: list[MPSConstraint]
     sos1: list[Any]
     sos2: list[Any]
+
+    @classmethod
+    def fromDict(cls, data: dict[str, Any]) -> MPS:
+        return cls(MPSParameters.fromDict(data["parameters"]),
+                   MPSObjective.fromDict(data["objective"]),
+                   [MPSVariable.fromDict(d) for d in data["variables"]],
+                   [MPSConstraint.fromDict(d) for d in data["constraints"]],
+                   data["sos1"],
+                   data["sos2"])
 
 
 def readMPS(path: str, sense: int, dropConsNames: bool = False) -> MPS:

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -308,9 +308,56 @@ class LpVariable(LpElement):
         return var
 
     def toDict(self) -> dict[str, Any]:
+        """
+        Exports a variable into a dict with its relevant information.
+
+        :return: a :py:class:`dict` with the variable information
+        :rtype: :dict
+        """
         return dataclasses.asdict(self.toDataclass())
 
-    to_dict = toDict
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Exports a variable into a dict with its relevant information.
+
+        This method is deprecated and :py:class:`LpVariable.toDict` should be used instead.
+
+        :return: a :py:class:`dict` with the variable information
+        :rtype: :dict
+        """
+        warnings.warn(
+            "LpVariable.to_dict is deprecated, use LpVariable.toDict instead",
+            category=DeprecationWarning,
+        )
+        return self.toDict()
+
+    @classmethod
+    def fromDict(cls, data: dict[str, Any]):
+        """
+        Initializes a variable object from information that comes from a dict.
+
+        :param data: a dict with the variable information
+        :return: a :py:class:`LpVariable`
+        :rtype: :LpVariable
+        """
+        return cls.fromDataclass(mpslp.MPSVariable.fromDict(data))
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]):
+        """
+        Initializes a variable object from information that comes from a dict.
+
+        This method is deprecated and :py:class:`LpVariable.fromDict` should be used instead.
+
+        :param data: a dict with the variable information
+        :return: a :py:class:`LpVariable`
+        :rtype: :LpVariable
+        """
+        warnings.warn(
+            "LpVariable.from_dict is deprecated, use LpVariable.fromDict instead",
+            category=DeprecationWarning,
+        )
+        return cls.fromDataclass(mpslp.MPSVariable.fromDict(data))
 
     def add_expression(self, e):
         self.expression = e
@@ -1004,6 +1051,30 @@ class LpAffineExpression(dict):
         """
         return [mpslp.MPSCoefficient(name=k.name, value=v) for k, v in self.items()]
 
+    def toDict(self) -> list[dict[str, Any]]:
+        """
+        exports the :py:class:`LpAffineExpression` into a list of dictionaries with the coefficients
+        it does not export the constant
+
+        :return: list of dictionaries with the coefficients
+        :rtype: list
+        """
+        return [{"name": k.name, "value": v} for k, v in self.items()]
+
+    def to_dict(self) -> list[dict[str, Any]]:
+        """
+        exports the :py:class:`LpAffineExpression` into a list of dictionaries with the coefficients
+        it does not export the constant
+
+        :return: list of dictionaries with the coefficients
+        :rtype: list
+        """
+        warnings.warn(
+            "LpAffineExpression.to_dict is deprecated, use LpAffineExpression.toDataclass instead",
+            category=DeprecationWarning,
+        )
+        return self.toDict()
+
 
 class LpConstraint:
     """An LP constraint"""
@@ -1531,9 +1602,24 @@ class LpProblem:
     def toDict(self):
         return dataclasses.asdict(self.toDataclass())
 
+    def to_dict(self):
+        warnings.warn(
+            "LpProblem.to_dict is deprecated, use LpProblem.toDict instead",
+            category=DeprecationWarning,
+        )
+        return self.toDict()
+
     @classmethod
     def fromDict(cls, data: dict[Any, Any]):
         return cls.fromDataclass(mpslp.MPS.fromDict(data))
+
+    @classmethod
+    def from_dict(cls, data: dict[Any, Any]):
+        warnings.warn(
+            "LpProblem.from_dict is deprecated, use LpProblem.fromDict instead",
+            category=DeprecationWarning,
+        )
+        return cls.fromDict(data)
 
     def toJson(self, filename: str, *args: Any, **kwargs: Any):
         """
@@ -1547,7 +1633,12 @@ class LpProblem:
         with open(filename, "w") as f:
             json.dump(self.toDict(), f, *args, **kwargs)
 
-    to_json = toJson
+    def to_json(self, filename: str, *args: Any, **kwargs: Any):
+        warnings.warn(
+            "LpProblem.to_json is deprecated, use LpProblem.toJson instead",
+            category=DeprecationWarning,
+        )
+        return self.toJson(filename, *args, **kwargs)
 
     @classmethod
     def fromJson(cls, filename: str) -> tuple[dict[str, LpVariable], LpProblem]:
@@ -1562,7 +1653,13 @@ class LpProblem:
             data = json.load(f)
         return cls.fromDict(data)
 
-    from_json = fromJson
+    @classmethod
+    def from_json(cls, filename: str):
+        warnings.warn(
+            "LpProblem.from_json is deprecated, use LpProblem.fromJson instead",
+            category=DeprecationWarning,
+        )
+        return cls.fromJson(filename)
 
     @classmethod
     def fromMPS(

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -1070,7 +1070,7 @@ class LpAffineExpression(dict):
         :rtype: list
         """
         warnings.warn(
-            "LpAffineExpression.to_dict is deprecated, use LpAffineExpression.toDataclass instead",
+            "LpAffineExpression.to_dict is deprecated, use LpAffineExpression.toDict instead",
             category=DeprecationWarning,
         )
         return self.toDict()

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -139,7 +139,6 @@ from . import mps_lp as mpslp
 from collections.abc import Iterable
 import logging
 import dataclasses
-import dacite
 
 log = logging.getLogger(__name__)
 
@@ -1534,7 +1533,7 @@ class LpProblem:
 
     @classmethod
     def fromDict(cls, data: dict[Any, Any]):
-        return cls.fromDataclass(dacite.from_dict(mpslp.MPS, data))
+        return cls.fromDataclass(mpslp.MPS.fromDict(data))
 
     def toJson(self, filename: str, *args: Any, **kwargs: Any):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ authors = [
     {name = "Franco Peschiera", email = "pchtsp@gmail.com"}
 ]
 maintainers= [{name= "Franco Peschiera", email= "pchtsp@gmail.com"}]
-dependencies = [
-    "dacite"
-]
+dependencies = []
 requires-python = ">=3.7"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ authors = [
     {name = "Franco Peschiera", email = "pchtsp@gmail.com"}
 ]
 maintainers= [{name= "Franco Peschiera", email= "pchtsp@gmail.com"}]
-dependencies = []
+dependencies = [
+    "dacite"
+]
 requires-python = ">=3.7"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
In the spirit of breaking out changes from #807, this PR includes rewriting parsing MPS files to use dataclasses instead of dicts.

This change does not add any new capabilities, and was done to:
1. Make it easier to type check the MPS parsing
2. To produce a more structured output from MPS parsing 

As raised in #807, a downside is that this adds a dependency on [dacite](https://github.com/konradhalas/dacite), whereas there were not previously any (depending on which backend is in use).