### PR TITLE
Add callback and parameter configuration support to CPLEX_PY solver

### DIFF
--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -292,7 +292,7 @@ class CPLEX_PY(LpSolver):
 
             Parameters should use dot notation as specified in the CPLEX documentation.
             The 'parameters.' prefix is optional. For example:
-                  
+
                   * parameters.advance (or advance)
                   * parameters.barrier.algorithm (or barrier.algorithm)
                   * parameters.mip.strategy.probe (or mip.strategy.probe)
@@ -513,8 +513,11 @@ class CPLEX_PY(LpSolver):
             """
             self.solverModel.parameters.timelimit.set(timeLimit)
 
-        def callSolver(self, isMIP,
-                       callback: Optional[Iterable[type[cplex.callbacks.Callback]]] = None):
+        def callSolver(
+            self,
+            isMIP,
+            callback: Optional[Iterable[type[cplex.callbacks.Callback]]] = None,
+        ):
             """
             Solves the problem with cplex
 

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -448,14 +448,26 @@ class CPLEX_PY(LpSolver):
                 self.set_param(param, value)
 
         def set_param(self, name: str, value):
+            """
+            Sets a parameter value using its name.
+            """
             param = self.search_param(name=name)
             param.set(value)
 
         def get_param(self, name: str):
+            """
+            Returns the value of a named parameter by searching within the instance's parameters.
+            """
             param = self.search_param(name=name)
             return param.get()
 
         def search_param(self, name: str):
+            """
+            Searches for a solver model parameter by its name and returns the corresponding attribute.
+
+            The method takes a parameter name string, processes it to remove the "parameters." prefix
+            and splits it by periods to traverse the attribute hierarchy of the solver model's parameters.
+            """
             name = name.replace("parameters.", "")
             param = self.solverModel.parameters
             for attr in name.split("."):
@@ -463,9 +475,15 @@ class CPLEX_PY(LpSolver):
             return param
 
         def get_all_params(self):
+            """
+            Returns all parameters from the solver model.
+            """
             return self.solverModel.parameters.get_all()
 
         def get_changed_params(self):
+            """
+            Returns the parameters that have been changed in the solver model.
+            """
             return self.solverModel.parameters.get_changed()
 
         def setlogfile(self, fileobj):

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -253,7 +253,7 @@ class CPLEX_PY(LpSolver):
     name = "CPLEX_PY"
     try:
         global cplex
-        import cplex  # type: ignore[import-not-found]
+        import cplex  # type: ignore[import-not-found, import-untyped, unused-ignore]
     except Exception as e:
         err = e
         """The CPLEX LP/MIP solver from python. Something went wrong!!!!"""

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -2093,7 +2093,7 @@ class CPLEX_PYTest(BaseSolverTest.PuLPTest):
         self.assertEqual(solver.get_changed_params(), [])
 
     def test_callback(self):
-        from cplex.callbacks import IncumbentCallback # type: ignore[import-not-found]
+        from cplex.callbacks import IncumbentCallback # type: ignore[import-not-found, import-untyped, unused-ignore]
         counter = 0
 
         class Callback(IncumbentCallback):

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -2038,7 +2038,7 @@ class CPLEX_CMDTest(BaseSolverTest.PuLPTest):
 
 
 class CPLEX_PYTest(BaseSolverTest.PuLPTest):
-    solveInst = CPLEX_CMD
+    solveInst = CPLEX_PY
 
 
 class XPRESS_CMDTest(BaseSolverTest.PuLPTest):

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -2093,7 +2093,8 @@ class CPLEX_PYTest(BaseSolverTest.PuLPTest):
         self.assertEqual(solver.get_changed_params(), [])
 
     def test_callback(self):
-        from cplex.callbacks import IncumbentCallback # type: ignore[import-not-found, import-untyped, unused-ignore]
+        from cplex.callbacks import IncumbentCallback  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
         counter = 0
 
         class Callback(IncumbentCallback):
@@ -2104,6 +2105,7 @@ class CPLEX_PYTest(BaseSolverTest.PuLPTest):
         problem = create_bin_packing_problem(bins=5, seed=55)
         pulpTestCheck(problem, self.solver, [LpStatusOptimal], callback=[Callback])
         self.assertGreaterEqual(counter, 1)
+
 
 class XPRESS_CMDTest(BaseSolverTest.PuLPTest):
     solveInst = XPRESS_CMD

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -2040,6 +2040,41 @@ class CPLEX_CMDTest(BaseSolverTest.PuLPTest):
 class CPLEX_PYTest(BaseSolverTest.PuLPTest):
     solveInst = CPLEX_PY
 
+    def _build(self, **kwargs):
+        problem = create_bin_packing_problem(bins=40, seed=99)
+        solver = self.solveInst(**kwargs)
+        solver.buildSolverModel(lp=problem)
+        return solver
+
+    def test_get_param(self):
+        solver = self._build()
+        self.assertEqual(solver.get_param("barrier.algorithm"), 0)
+
+    def test_get_param_with_full_path(self):
+        solver = self._build()
+        self.assertEqual(solver.get_param("parameters.barrier.algorithm"), 0)
+
+    def test_set_param(self):
+        param = "barrier.limits.iteration"
+        solver = self._build(**{param: 100})
+        self.assertEqual(solver.get_param(name=param), 100)
+
+    def test_set_param_with_full_path(self):
+        param = "parameters.barrier.limits.iteration"
+        solver = self._build(**{param: 100})
+        self.assertEqual(solver.get_param(name=param), 100)
+
+    def test_changed_param(self):
+        param = "parameters.barrier.limits.iteration"
+        solver = self._build(**{param: 100})
+        self.assertEqual(len(solver.get_changed_params()), 1)
+
+    def test_set_all_params(self):
+        solver = self._build()
+        parameters = solver.get_all_params()
+        for param, value in parameters:
+            solver.set_param(name=str(param), value=value)
+        self.assertEqual(solver.get_changed_params(), [])
 
 class XPRESS_CMDTest(BaseSolverTest.PuLPTest):
     solveInst = XPRESS_CMD

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -2041,25 +2041,41 @@ class CPLEX_PYTest(BaseSolverTest.PuLPTest):
     solveInst = CPLEX_PY
 
     def _build(self, **kwargs):
+        """
+        Builds and returns a solver instance after creating and initializing a bin packing problem.
+        """
         problem = create_bin_packing_problem(bins=40, seed=99)
         solver = self.solveInst(**kwargs)
         solver.buildSolverModel(lp=problem)
         return solver
 
     def test_get_param(self):
+        """
+        Tests the `get_param` method of the solver instance to ensure the correct
+        value is returned for a given parameter key.
+        """
         solver = self._build()
         self.assertEqual(solver.get_param("barrier.algorithm"), 0)
 
     def test_get_param_with_full_path(self):
+        """
+        Test case for accessing a solver's parameter by its full hierarchical path.
+        """
         solver = self._build()
         self.assertEqual(solver.get_param("parameters.barrier.algorithm"), 0)
 
     def test_set_param(self):
+        """
+        Tests the functionality for setting a parameter in the solver.
+        """
         param = "barrier.limits.iteration"
         solver = self._build(**{param: 100})
         self.assertEqual(solver.get_param(name=param), 100)
 
     def test_set_param_with_full_path(self):
+        """
+        Tests the functionality for setting a parameter using its full hierarchical path in the solver.
+        """
         param = "parameters.barrier.limits.iteration"
         solver = self._build(**{param: 100})
         self.assertEqual(solver.get_param(name=param), 100)

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -2076,6 +2076,19 @@ class CPLEX_PYTest(BaseSolverTest.PuLPTest):
             solver.set_param(name=str(param), value=value)
         self.assertEqual(solver.get_changed_params(), [])
 
+    def test_callback(self):
+        from cplex.callbacks import IncumbentCallback # type: ignore[import-not-found]
+        counter = 0
+
+        class Callback(IncumbentCallback):
+            def __call__(self):
+                nonlocal counter
+                counter += 1
+
+        problem = create_bin_packing_problem(bins=5, seed=55)
+        pulpTestCheck(problem, self.solver, [LpStatusOptimal], callback=[Callback])
+        self.assertGreaterEqual(counter, 1)
+
 class XPRESS_CMDTest(BaseSolverTest.PuLPTest):
     solveInst = XPRESS_CMD
 


### PR DESCRIPTION
This pull request includes several updates and improvements related to the CPLEX solver:

- Updated the `CPLEX_PYTest` suite to use `CPLEX_PY` instead of `CPLEX_CMD`.
- Extended the solver API to accept custom CPLEX solver parameters via the `solverParams` argument, offering more control. Added utility methods to manage these parameters, along with unit tests to ensure proper behavior.
- Introduced support for registering CPLEX callbacks by adding an optional `callback` parameter. Included a test case to validate this functionality.