### PR TITLE
Add ruff linter to CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,8 @@ repos:
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.4
+    hooks:
+    -   id: ruff
+        args: [--exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,36 @@ exclude = '/(\.eggs|\.git|\.hg|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|d
 [project.optional-dependencies]
 open_py = ["cylp; sys_platform != 'win32'", "highspy", "pyscipopt"]
 public_py = ["gurobipy", "coptpy", 'xpress']
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+fix = false
+
+[tool.ruff.lint]
+unfixable = []
+
+select = [
+  # pyflakes
+  "F",
+  # pycodestyle
+  "E", "W",
+]
+
+ignore = [
+    "E501", # line too long
+    "F405", # name may be undefined, but is defined in a different module
+    "E731", # do not assign a lambda expression, use a def,
+    "F841", # local variable is assigned to but never used
+    "E722", # do not use bare except, specify exception,
+    "E711", # do not compare types, use isinstance instead,
+    "E402", # module level import not at top of file
+    "F401", # module imported but unused
+    "F403", # from module import * used; unable to detect undefined names
+    "F541", # f-string without any placeholders
+    "E741", # ambiguous variable name
+    "E714", # Test for object identity should be `is not`
+    "E713", # Test for membership should be `not in`
+]
+
+exclude = ["doc/**/*.py", "examples/**/*.py",]


### PR DESCRIPTION
Hello,

This PR adds the config for [ruff](https://github.com/astral-sh/ruff), a very fast linter that is becoming the industry standard to pre-commit CI. Let me know if this adoption is welcome or not. 

A lot of lint violations can be fixed/auto-fixed, but we can leave it for later after we have the enforcement in place. 

Look forward to your feedback.