### PR TITLE
Removes test import from pulp.__init__

### DIFF
--- a/pulp/__init__.py
+++ b/pulp/__init__.py
@@ -29,13 +29,13 @@ Module file that imports all of the pulp functions
 
 Copyright 2007- Stuart Mitchell (s.mitchell@auckland.ac.nz)
 """
+
 from .constants import VERSION
 
 from .pulp import *
 from .apis import *
 from .utilities import *
 from .constants import *
-from .tests import pulpTestAll
 
 __doc__ = pulp.__doc__  # type: ignore[name-defined]
 __version__ = VERSION

--- a/pulp/__init__.py
+++ b/pulp/__init__.py
@@ -29,7 +29,6 @@ Module file that imports all of the pulp functions
 
 Copyright 2007- Stuart Mitchell (s.mitchell@auckland.ac.nz)
 """
-
 from .constants import VERSION
 
 from .pulp import *

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -895,7 +895,7 @@ class BaseSolverTest:
             """
             Test the availability of the function pulpTestAll
             """
-            from pulp import pulpTestAll
+            from pulp.tests.run_tests import pulpTestAll
 
         def test_export_dict_LP(self):
             prob = LpProblem(self._testMethodName, const.LpMinimize)


### PR DESCRIPTION
Stops broad import of tests for non-test usage.
Fixes #848 

More generally, probably best practice to remove pulp's runtime dependency of pulp on its own tests.

Note: test usage via `pulpTestAll` still readily available as:
`python -m pulp.tests.run_tests`