### PR TITLE
Refactored solverParams and solverModel initialization in CPLEX_PY

### DIFF
--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -308,7 +308,7 @@ class CPLEX_PY(LpSolver):
                 logPath=logPath,
                 threads=threads,
             )
-            self.solverParams = solverParams
+            self.solver_params = solverParams
 
         def available(self):
             """True if the solver is available"""
@@ -444,7 +444,7 @@ class CPLEX_PY(LpSolver):
                 self.solverModel.MIP_starts.add(
                     cplex.SparsePair(ind=ind, val=val), effort, "1"
                 )
-            for param, value in self.solverParams.items():
+            for param, value in self.solver_params.items():
                 self.set_param(param, value)
 
         def set_param(self, name: str, value):

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -309,6 +309,7 @@ class CPLEX_PY(LpSolver):
                 threads=threads,
             )
             self.solver_params = solverParams
+            self.solverModel = None
 
         def available(self):
             """True if the solver is available"""
@@ -461,6 +462,22 @@ class CPLEX_PY(LpSolver):
             param = self.search_param(name=name)
             return param.get()
 
+        @staticmethod
+        def check_solverModel(func):
+            """
+            Decorator that checks if the solverModel is initialized.
+
+            :raises PulpSolverError: If the ``solverModel`` attribute is not initialized
+            """
+
+            def wrapper(self, *args, **kwargs):
+                if self.solverModel is None:
+                    raise PulpSolverError("solverModel not initialized")
+                return func(self, *args, **kwargs)
+
+            return wrapper
+
+        @check_solverModel
         def search_param(self, name: str):
             """
             Searches for a solver model parameter by its name and returns the corresponding attribute.
@@ -474,12 +491,14 @@ class CPLEX_PY(LpSolver):
                 param = getattr(param, attr)
             return param
 
+        @check_solverModel
         def get_all_params(self):
             """
             Returns all parameters from the solver model.
             """
             return self.solverModel.parameters.get_all()
 
+        @check_solverModel
         def get_changed_params(self):
             """
             Returns the parameters that have been changed in the solver model.

--- a/pulp/apis/cplex_api.py
+++ b/pulp/apis/cplex_api.py
@@ -515,7 +515,7 @@ class CPLEX_PY(LpSolver):
 
         def callSolver(
             self,
-            isMIP,
+            isMIP: bool,
             callback: Optional[Iterable[type[cplex.callbacks.Callback]]] = None,
         ):
             """

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -19,6 +19,7 @@ from pulp import (
     LpFractionConstraint,
     LpProblem,
     LpVariable,
+    PulpSolverError,
 )
 from pulp import constants as const
 from pulp import lpSum
@@ -2071,7 +2072,7 @@ class CPLEX_CMDTest(BaseSolverTest.PuLPTest):
 
 
 class CPLEX_PYTest(BaseSolverTest.PuLPTest):
-    solveInst = solvers.CPLEX_CMD
+    solveInst = solvers.CPLEX_PY
 
     def _build(self, **kwargs):
         """
@@ -2081,6 +2082,15 @@ class CPLEX_PYTest(BaseSolverTest.PuLPTest):
         solver = self.solveInst(**kwargs)
         solver.buildSolverModel(lp=problem)
         return solver
+
+    def test_search_param_without_solver_model(self):
+        """
+        Tests the behavior of the `search_param` method when invoked without a `solverModel`
+        initialized. Validates that an appropriate error is raised under these conditions.
+        """
+        solver = self.solveInst()
+        with self.assertRaises(PulpSolverError):
+            solver.search_param("barrier.algorithm")
 
     def test_get_param(self):
         """
@@ -2136,7 +2146,9 @@ class CPLEX_PYTest(BaseSolverTest.PuLPTest):
                 counter += 1
 
         problem = create_bin_packing_problem(bins=5, seed=55)
-        pulpTestCheck(problem, self.solver, [LpStatusOptimal], callback=[Callback])
+        pulpTestCheck(
+            problem, self.solver, [const.LpStatusOptimal], callback=[Callback]
+        )
         self.assertGreaterEqual(counter, 1)
 
 


### PR DESCRIPTION
This pull request is related to #850

- Refactored `solverParams` to `solver_params` for alignment with Gurobi API.
-  Explicitly typing the `isMIP` parameter as `bool`.
- Implemented a `check_solverModel` decorator to ensure `solverModel` is initialized before executing methods.
- Added a unit test to verify `search_param` raises `PulpSolverError` when `solverModel` is uninitialized.