### PR TITLE
Remove `test_set_all_params` to fix #861

### DIFF
--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -2128,13 +2128,6 @@ class CPLEX_PYTest(BaseSolverTest.PuLPTest):
         solver = self._build(**{param: 100})
         self.assertEqual(len(solver.get_changed_params()), 1)
 
-    def test_set_all_params(self):
-        solver = self._build()
-        parameters = solver.get_all_params()
-        for param, value in parameters:
-            solver.set_param(name=str(param), value=value)
-        self.assertEqual(solver.get_changed_params(), [])
-
     def test_callback(self):
         from cplex.callbacks import IncumbentCallback  # type: ignore[import-not-found, import-untyped, unused-ignore]
 


### PR DESCRIPTION
The test applies the parameter's default value to the parameter itself, just to verify that it works for everyone. But apparently, it's not possible to assign a value to some parameters depending on the Python version and operating system.