### PR TITLE
Add support for initial values at construction and extended variable types

### DIFF
--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -274,12 +274,15 @@ class LpVariable(LpElement):
         upBound: Optional[float] = None,
         cat: str = const.LpContinuous,
         e=None,
+        varValue=None,
     ):
         LpElement.__init__(self, name)
         self._lowbound_original = self.lowBound = lowBound
         self._upbound_original = self.upBound = upBound
         self.cat = cat
         self.varValue = None
+        if varValue is not None:
+            self.setInitialValue(val=varValue)
         self.dj = None
         if cat == const.LpBinary:
             self._lowbound_original = self.lowBound = 0

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -333,10 +333,13 @@ class LpVariable(LpElement):
         :rtype: :LpVariable
         """
         var = cls(
-            name=mps.name, lowBound=mps.lowBound, upBound=mps.upBound, cat=mps.cat
+            name=mps.name,
+            lowBound=mps.lowBound,
+            upBound=mps.upBound,
+            cat=mps.cat,
+            varValue=mps.varValue,
         )
         var.dj = mps.dj
-        var.varValue = mps.varValue
         return var
 
     def toDict(self) -> dict[str, Any]:

--- a/pulp/pulp.py
+++ b/pulp/pulp.py
@@ -718,6 +718,24 @@ class LpVariable(LpElement):
         self.bounds(self._lowbound_original, self._upbound_original)
 
 
+class LpBinaryVariable(LpVariable):
+    """
+    This class models an LP Binary Variable with the specified associated parameters
+    """
+
+    def __init__(self, name: str, **kwargs):
+        LpVariable.__init__(self, name=name, cat=const.LpBinary, **kwargs)
+
+
+class LpIntegerVariable(LpVariable):
+    """
+    This class models an LP Integer Variable with the specified associated parameters
+    """
+
+    def __init__(self, name: str, **kwargs):
+        LpVariable.__init__(self, name=name, cat=const.LpInteger, **kwargs)
+
+
 class LpAffineExpression(dict):
     """
     A linear combination of :class:`LpVariables<LpVariable>`.

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -1882,6 +1882,12 @@ class BaseSolverTest:
             self.assertEqual(LpIntegerVariable("x", lowBound=0).lowBound, 0)
             self.assertEqual(LpIntegerVariable("x", upBound=10).upBound, 10)
 
+        def test_lp_variable_with_0_as_initial_value(self):
+            self.assertEqual(LpVariable("x", varValue=0).varValue, 0)
+
+        def test_lp_variable_with_10_as_initial_value(self):
+            self.assertEqual(LpVariable("x", varValue=10).varValue, 10)
+
 
 class PULP_CBC_CMDTest(BaseSolverTest.PuLPTest):
     solveInst = solvers.PULP_CBC_CMD

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -14,9 +14,11 @@ from typing import Union, Optional, Type
 from pulp import (
     FixedElasticSubProblem,
     LpAffineExpression,
+    LpBinaryVariable,
     LpConstraint,
     LpConstraintVar,
     LpFractionConstraint,
+    LpIntegerVariable,
     LpProblem,
     LpVariable,
     PulpSolverError,
@@ -1868,6 +1870,17 @@ class BaseSolverTest:
 
             second_expression_2 = x * m2 - 6 - y
             self.assertEqual(str(second_expression_2), "8.1*x - y - 6.0")
+
+        def test_lp_binary_variable(self):
+            self.assertTrue(LpBinaryVariable("x").isBinary())
+            self.assertTrue(LpBinaryVariable("x").isInteger())
+
+        def test_lp_integer_variable(self):
+            self.assertTrue(LpIntegerVariable("x").isInteger())
+
+        def test_lp_integer_variable_with_bounds(self):
+            self.assertEqual(LpIntegerVariable("x", lowBound=0).lowBound, 0)
+            self.assertEqual(LpIntegerVariable("x", upBound=10).upBound, 10)
 
 
 class PULP_CBC_CMDTest(BaseSolverTest.PuLPTest):


### PR DESCRIPTION
### Summary

- Introduced `LpBinaryVariable` and `LpIntegerVariable` classes to extend functionality.
- Enabled setting initial values for `LpVariable` during its creation.
- Refactored `fromDataclass` to include `varValue` for convenience and clarity during variable instantiation.
- Added test cases for all the changes.

### Motivation

I’ve been working on problems where most variables are binary or integer. It’s a bit annoying having to specify `cat` for each one, so I created subclasses to handle this.
Along the same lines, I added the option to specify `varValue` when creating the variable.