### PR TITLE
Check if the solution variables content is not None

### DIFF
--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -2410,7 +2410,7 @@ def pulpTestCheck(
         )
     if sol is not None:
         for v, x in sol.items():
-            if abs(v.varValue - x) > eps:
+            if v.varValue is not None and abs(v.varValue - x) > eps:
                 dumpTestProblem(prob)
                 raise PulpError(
                     "Tests failed for solver {}:\nvar {} == {} != {}".format(


### PR DESCRIPTION
When running pytest there is a TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'. This is because there is no checking of the content of variables before doing operations with integers.