### PR TITLE
Use dynamic versioning and bump version in constants.py

### DIFF
--- a/pulp/constants.py
+++ b/pulp/constants.py
@@ -27,7 +27,7 @@
 This file contains the constant definitions for PuLP
 Note that hopefully these will be changed into something more pythonic
 """
-VERSION = "3.0.2"
+VERSION = "3.2.3"
 EPS = 1e-7
 
 # variable categories

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PuLP"
-version = "3.2.3"
+dynamic = ["version"]
 description = "PuLP is an LP modeler written in python. PuLP can generate MPS or LP files and call GLPK, COIN CLP/CBC, CPLEX, and GUROBI to solve linear problems."
 authors = [
     {name = 'J.S. Roy'},
@@ -65,6 +65,9 @@ packages = [
         "pulp.tests"]
 # This is a workaround for https://github.com/astral-sh/uv/issues/9513
 license-files = []
+
+[tool.setuptools.dynamic]
+version = {attr = "pulp.__version__"}
 
 [tool.setuptools.package-data]
 "pulp.solverdir.cbc.linux.i32"= ["*", "*.*"]


### PR DESCRIPTION
The version is manually specified in `pyproject.toml` and `constants.py`. The version number in `constants.py` has diverged from that in the `pyproject.toml` such that for `pulp==3.2.3` the `pulp.__version__ == 3.0.2`.

This PR makes the pyproject version dynamic so that version bumps can be done entirely from constants.py, avoiding the potential for mismatches in the future.