### PR TITLE
Fix license related setuptools deprecation warnings.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,12 @@ maintainers= [{name= "Franco Peschiera", email= "pchtsp@gmail.com"}]
 dependencies = []
 requires-python = ">=3.9"
 readme = "README.rst"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering :: Mathematics",
@@ -39,7 +39,7 @@ module = [
 follow_imports = "skip"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [dependency-groups]
@@ -63,8 +63,6 @@ packages = [
         "pulp.solverdir.cbc.osx.i64",
         "pulp.apis",
         "pulp.tests"]
-# This is a workaround for https://github.com/astral-sh/uv/issues/9513
-license-files = []
 
 [tool.setuptools.package-data]
 "pulp.solverdir.cbc.linux.i32"= ["*", "*.*"]


### PR DESCRIPTION
Resolves the following setuptools deprecation warnings that are raised during build:
```
SetuptoolsDeprecationWarning: 'tool.setuptools.license-files' is deprecated in favor of 'project.license-files' (available on setuptools>=77.0.0).
!!
        ********************************************************************************

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files for details.
        ********************************************************************************
!!
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!
        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
!!
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!
        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
!!
```