### PR TITLE
Validate solver solution count before processing

### DIFF
--- a/pulp/apis/scip_api.py
+++ b/pulp/apis/scip_api.py
@@ -565,6 +565,8 @@ class SCIP_PY(LpSolver):
             if solutionStatus in possible_solution_found_statuses:
                 try:  # Feasible solution found
                     solution = lp.solverModel.getBestSol()
+                    if lp.solverModel.getNSols() <= 0:
+                        raise ValueError('Returned solution by solver cannot be trusted')
                     for variable in lp._variables:
                         variable.varValue = solution[variable.solverVar]
                     for constraint in lp.constraints.values():


### PR DESCRIPTION
Add validation for the number of solutions returned by the solver.

Should fix #876

This PR has not been tested (and I'm actually a little bit unsure why there is the try catch in the first place).
But the solution probably goes in this direction.