### PR TITLE
Fix(gurobi_py): Correctly handle binary variables in MIP solve

### DIFF
--- a/pulp/apis/gurobi_api.py
+++ b/pulp/apis/gurobi_api.py
@@ -302,6 +302,8 @@ class GUROBI(LpSolver):
                 varType = gp.GRB.CONTINUOUS
                 if var.cat == constants.LpInteger and self.mip:
                     varType = gp.GRB.INTEGER
+                if var.cat == constants.LpBinary and self.mip:
+                    varType = gp.GRB.BINARY
                 # only add variable once, ow new variable will be created.
                 if not hasattr(var, "solverVar") or nvars == 0:
                     var.solverVar = lp.solverModel.addVar(


### PR DESCRIPTION
Hello,

This PR fixes a bug in the gurobi_py solver interface where binary variables (LpBinary) were being incorrectly treated as general countinuos (GRB.CONTINUOUS) when solving an MIP problem (i.e., when self.mip is True).

Description of the Bug
Currently, the variable type logic is:

"""
varType = gp.GRB.CONTINUOUS
if var.cat == constants.LpInteger and self.mip:
    varType = gp.GRB.INTEGER
"""

Proposed Change
This patch adds a subsequent if statement to ensure that LpBinary variables are correctly identified and set to GRB.BINARY

Change:
"""
varType = gp.GRB.CONTINUOUS
if var.cat == constants.LpInteger and self.mip:
    varType = gp.GRB.INTEGER
if var.cat == constants.LpBinary and self.mip:
    varType = gp.GRB.BINARY
"""