### PR TITLE
Minor documentation improvements

### DIFF
--- a/doc/source/develop/contribute.rst
+++ b/doc/source/develop/contribute.rst
@@ -22,6 +22,8 @@ We will use plain git through the command line but feel free to use the git clie
 Forking PuLP
 --------------
 
+The PuLP repository is available at `https://github.com/coin-or/pulp <https://github.com/coin-or/pulp>`_.
+
 You can follow the github guides to fork a project: `here <https://guides.github.com/activities/forking/>`_ and `also here <https://docs.github.com/en/github/getting-started-with-github/quickstart/fork-a-repo>`_.
 
 You need a github account to fork a github project. It's free.
@@ -29,9 +31,9 @@ You need a github account to fork a github project. It's free.
 Cloning the project
 ----------------------------
 
-You first need to download the pulp project from your fork. In the following command replace ``pchtsp`` with your actual username::
+You first need to download the pulp project from your fork. In the following command replace ``<USERNAME>`` with your actual username::
 
-    git clone git@github.com:pchtsp/pulp.git
+    git clone git@github.com:<USERNAME>/pulp.git
 
 That's it, you will download the whole project.
 

--- a/doc/source/guides/how_to_mip_start.rst
+++ b/doc/source/guides/how_to_mip_start.rst
@@ -1,7 +1,7 @@
 How to warm-start a solver
 ======================================
 
-Many solvers permit the possibility of giving a valid (or parcially valid in some cases) solution so the solver can start from that solution. This can lead to performance gains.
+Many solvers permit the possibility of giving a valid (or partially valid in some cases) solution so the solver can start from that solution. This can lead to performance gains.
 
 
 Supported solver APIs


### PR DESCRIPTION
Just some minor things that I stumbled upon.

1. Spelling of partially
2. An easy to find link for the repo (I had to google for it)
3. Replace `pchtsp` with `<USERNAME>` which is more obvious that it should be replaced (I didn't read that carefully and thought the repo was at `github.com/pchtsp/pulp/` based on this...)