### PR TITLE
Handle cuOpt UnboundedOrInfeasible status (11) in CUOPT adapter and tests

### DIFF
--- a/pulp/apis/cuopt_api.py
+++ b/pulp/apis/cuopt_api.py
@@ -112,6 +112,12 @@ class CUOPT(LpSolver):
                 7: LpStatusNotSolved,  # Primal Feasible
                 8: LpStatusNotSolved,  # Feasible Found
                 9: LpStatusNotSolved,  # Concurrent Limit
+                10: LpStatusNotSolved,  # Work Limit
+                # cuOpt returns UnboundedOrInfeasible when the presolver
+                # detects one of the two but cannot disambiguate. PuLP has
+                # no combined status, so map to Undefined (matches how
+                # GLPK_CMD reports the same situation).
+                11: LpStatusUndefined,  # Unbounded or Infeasible
             }
 
             status = CuoptStatus.get(solutionStatus, LpStatusUndefined)

--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -656,6 +656,14 @@ class BaseSolverTest:
                     self.solver,
                     [const.LpStatusInfeasible, const.LpStatusUnbounded],
                 )
+            elif self.solver.name == "CUOPT":
+                # cuOpt reports UnboundedOrInfeasible (mapped to Undefined)
+                # for problems where its presolver cannot disambiguate.
+                pulpTestCheck(
+                    prob,
+                    self.solver,
+                    [const.LpStatusUnbounded, const.LpStatusUndefined],
+                )
             elif self.solver.name in ["COINMP_DLL", "MIPCL_CMD"]:
                 # COINMP_DLL is just plain wrong
                 # also MIPCL_CMD
@@ -1010,8 +1018,9 @@ class BaseSolverTest:
             prob += c1 <= 0
             if self.solver.name in ["GUROBI_CMD", "SCIP_CMD", "FSCIP_CMD", "SCIP_PY"]:
                 pulpTestCheck(prob, self.solver, [const.LpStatusNotSolved])
-            elif self.solver.name in ["GLPK_CMD"]:
-                # GLPK_CMD returns InfeasibleOrUnbounded
+            elif self.solver.name in ["GLPK_CMD", "CUOPT"]:
+                # These solvers may return InfeasibleOrUnbounded (reported as
+                # Undefined) rather than proving infeasibility.
                 pulpTestCheck(
                     prob,
                     self.solver,


### PR DESCRIPTION
## Summary

cuOpt added a new termination status (value 11, \`UnboundedOrInfeasible\`) that its presolver returns when infeasibility and unboundedness cannot be disambiguated. PuLP has no combined status, so the adapter maps it to \`LpStatusUndefined\` (mirroring how \`GLPK_CMD\` reports the same case). Status 10 (\`WorkLimit\`) is added explicitly at the same time.

Two test branches are updated so \`CUOPT\` is accepted in the tolerant paths that \`GLPK_CMD\` / \`GUROBI\` / \`MOSEK\` already use:

- \`test_integer_infeasible_2\`: accept \`Infeasible\` or \`Undefined\` for \`CUOPT\`
- \`test_unbounded\`: accept \`Unbounded\` or \`Undefined\` for \`CUOPT\`

Tracked upstream in NVIDIA/cuopt#1114.