### PR TITLE
Update Xpress solver integration for API v9.8 with backward compatibility

### DIFF
--- a/doc/source/guides/how_to_configure_solvers.rst
+++ b/doc/source/guides/how_to_configure_solvers.rst
@@ -140,6 +140,21 @@ GUROBI
     set PATH=%PATH%;%GUROBI_HOME%/bin
     set LD_LIBRARY_PATH=%LD_LIBRARY_PATH%;%GUROBI_HOME%/lib
 
+XPRESS
+*******
+
+**Linux / Mac**: add the following lines to the ~.bashrc (or ~.profile or /etc/profile or /etc/bash.bashrc) file::
+
+    export XPRESSDIR="/opt/xpressmp"
+    export PATH="${PATH}:${XPRESSDIR}/bin"
+    export XPAUTH_PATH="${XPRESSDIR}/bin/xpauth.xpr"
+
+**Windows**: add the following environment variables (via the command line or graphical user interface)::
+
+    set XPRESSDIR=C:/xpressmp
+    set PATH=%PATH%;%XPRESSDIR%/bin
+    set XPAUTH_PATH=%XPRESSDIR%/bin/xpauth.xpr
+
 
 Configuring where the CMD solvers write their temporary files
 ---------------------------------------------------------------------------
@@ -224,6 +239,29 @@ Following my installation paths it would be (Linux)::
      sudo python3 setup.py install
 
 As you can see, it is necessary to have admin rights to install it.
+
+Installing XPRESS_PY
+***********************
+
+This solver works by installing the `xpress` Python package, which includes a runtime distribution of the Xpress Optimizer libraries, and a Community License (free of charge, problem size limits apply).
+
+To install the Xpress Python package:
+    - PYPI: `pip install xpress`
+    - CONDA: `conda install -c fico-xpress xpress`
+
+If you plan to work with larger models and acquire an Academic or Commercial License, contact FICO support to obtain a license file, and then set the `XPAUTH_PATH` environment variable to the location of your license file.
+
+**Linux / Mac**: add the following line to the ~.bashrc (or ~.profile or /etc/profile or /etc/bash.bashrc) file::
+
+    export XPAUTH_PATH="/path/to/your/xpauth.xpr"
+
+**Windows**: add the following environment variable (via the command line or graphical user interface)::
+
+    set XPAUTH_PATH=C:/path/to/your/xpauth.xpr
+
+*Even though the XPRESS_PY solver interface in PuLP works for Xpress versions 9.0+, it has been updated and tested using Xpress version 9.8. If you have an older version of Xpress, please consider updating to this version.*
+
+**License tokens:** ``XPRESS`` (CMD) acquires and releases a license token per subprocess - once per ``model.solve()`` call. ``XPRESS_PY`` holds a token for the lifetime of the Python process from the moment ``xpress`` is imported. In batch environments where license tokens are shared across jobs, use ``xp.init()`` as a context manager around each job to scope the token lifetime and release it between solves.
 
 .. _solver-specific-config:
 

--- a/pulp/apis/xpress_api.py
+++ b/pulp/apis/xpress_api.py
@@ -26,6 +26,7 @@
 
 import re
 import sys
+import warnings
 
 from .. import constants
 from .core import LpSolver, LpSolver_CMD, PulpSolverError, subprocess
@@ -97,7 +98,20 @@ class XPRESS(LpSolver_CMD):
 
     def available(self):
         """True if the solver is available"""
-        return self.executable(self.path)
+        if self.executable(self.path):
+            return True
+        try:
+            import xpress  # noqa: F401
+
+            warnings.warn(
+                "Xpress optimizer binary not found. "
+                "Consider using XPRESS_PY instead: pip install xpress",
+                UserWarning,
+                stacklevel=2,
+            )
+        except ImportError:
+            pass
+        return False
 
     def actualSolve(self, lp):
         """Solve a well formulated lp problem"""
@@ -123,7 +137,7 @@ class XPRESS(LpSolver_CMD):
                 4: constants.LpStatusUndefined,  # XPRS_MIP_SOLUTION
                 5: constants.LpStatusInfeasible,  # XPRS_MIP_INFEAS
                 6: constants.LpStatusOptimal,  # XPRS_MIP_OPTIMAL
-                7: constants.LpStatusUndefined,  # XPRS_MIP_UNBOUNDED
+                7: constants.LpStatusUnbounded,  # XPRS_MIP_UNBOUNDED
             }
             statuskey = "mipstatus"
         else:
@@ -409,17 +423,29 @@ class XPRESS_PY(LpSolver):
 
             if self._export is not None:
                 if self._export.lower().endswith(".lp"):
-                    model.write(self._export, "l")
+                    try:  # New API first
+                        model.writeProb(self._export, "l")
+                    except AttributeError:  # Fallback to deprecated API
+                        model.write(self._export, "l")
                 else:
-                    model.write(self._export)
+                    try:  # New API first
+                        model.writeProb(self._export)
+                    except AttributeError:  # Fallback to deprecated API
+                        model.write(self._export)
             if prepare is not None:
                 prepare(lp)
             if _ismip(lp) and not self.mip:
                 # Solve only the LP relaxation
-                model.lpoptimize()
+                try:  # New API first
+                    model.lpOptimize()
+                except AttributeError:  # Fallback to deprecated API
+                    model.lpoptimize()
             else:
-                # In all other cases, solve() does the correct thing
-                model.solve()
+                # In all other cases, optimize() does the correct thing
+                try:  # New API first
+                    model.optimize()
+                except AttributeError:  # Fallback to deprecated API
+                    model.solve()
         except (xpress.ModelError, xpress.InterfaceError, xpress.SolverError) as err:
             raise PulpSolverError(str(err))
 
@@ -447,88 +473,67 @@ class XPRESS_PY(LpSolver):
                 )
                 xpress_cons.append((n, c, h))
 
-            if _ismip(lp) and self.mip:
-                # ------- MIP branch -------
-                vals = slacks = duals = djs = None
-                statusmap = {
-                    0: constants.LpStatusUndefined,  # XPRS_MIP_NOT_LOADED
-                    1: constants.LpStatusUndefined,  # XPRS_MIP_LP_NOT_OPTIMAL
-                    2: constants.LpStatusUndefined,  # XPRS_MIP_LP_OPTIMAL
-                    3: constants.LpStatusUndefined,  # XPRS_MIP_NO_SOL_FOUND
-                    4: constants.LpStatusUndefined,  # XPRS_MIP_SOLUTION
-                    5: constants.LpStatusInfeasible,  # XPRS_MIP_INFEAS
-                    6: constants.LpStatusOptimal,  # XPRS_MIP_OPTIMAL
-                    7: constants.LpStatusUndefined,  # XPRS_MIP_UNBOUNDED
-                }
-                statuskey = "mipstatus"
+            vals = slacks = duals = djs = None
 
-                # New API first
-                try:
-                    var_vals = model.getSolution([h for _, h in xpress_vars])
-                    slacks = (
-                        model.getSlacks([h for _, _, h in xpress_cons])
-                        if xpress_cons
-                        else None
-                    )
-                    vals = var_vals
-                except Exception as e:
-                    # Fallback to deprecated API (avoids DeprecationWarning only if not hit)
-                    try:
-                        print(e)
-                        x_list, s_list = [], []
-                        model.getmipsol(x_list, s_list)
-                        vals, slacks = (
-                            x_list if x_list else None,
-                            s_list if s_list else None,
-                        )
-                    except Exception:
-                        vals = slacks = None
+            # Resolve solstatus enum constants with integer fallbacks for older versions
+            _SS = getattr(xpress, "SolStatus", None)
+            _SS_NOTFOUND = getattr(_SS, "NOTFOUND", 0) if _SS else 0
+            _SS_OPTIMAL = getattr(_SS, "OPTIMAL", 1) if _SS else 1
+            _SS_FEASIBLE = getattr(_SS, "FEASIBLE", 2) if _SS else 2
+            _SS_INFEASIBLE = getattr(_SS, "INFEASIBLE", 3) if _SS else 3
+            _SS_UNBOUNDED = getattr(_SS, "UNBOUNDED", 4) if _SS else 4
 
-                duals = None
-                djs = None
+            # Map solstatus to (status, sol_status) tuples for detailed status reporting
+            statusmap = {
+                _SS_NOTFOUND: (
+                    constants.LpStatusNotSolved,
+                    constants.LpSolutionNoSolutionFound,
+                ),
+                _SS_OPTIMAL: (
+                    constants.LpStatusOptimal,
+                    constants.LpSolutionOptimal,
+                ),
+                _SS_FEASIBLE: (
+                    constants.LpStatusUndefined,
+                    constants.LpSolutionIntegerFeasible,
+                ),
+                _SS_INFEASIBLE: (
+                    constants.LpStatusInfeasible,
+                    constants.LpSolutionInfeasible,
+                ),
+                _SS_UNBOUNDED: (
+                    constants.LpStatusUnbounded,
+                    constants.LpSolutionUnbounded,
+                ),
+            }
 
-            else:
-                # ------- LP (continuous) branch -------
-                vals = slacks = duals = djs = None
-                statusmap = {
-                    0: constants.LpStatusNotSolved,  # XPRS_LP_UNSTARTED
-                    1: constants.LpStatusOptimal,  # XPRS_LP_OPTIMAL
-                    2: constants.LpStatusInfeasible,  # XPRS_LP_INFEAS
-                    3: constants.LpStatusUndefined,  # XPRS_LP_CUTOFF
-                    4: constants.LpStatusUndefined,  # XPRS_LP_UNFINISHED
-                    5: constants.LpStatusUnbounded,  # XPRS_LP_UNBOUNDED
-                    6: constants.LpStatusUndefined,  # XPRS_LP_CUTOFF_IN_DUAL
-                    7: constants.LpStatusNotSolved,  # XPRS_LP_UNSOLVED
-                    8: constants.LpStatusUndefined,  # XPRS_LP_NONCONVEX
-                }
-                statuskey = "lpstatus"
+            solstatus = model.attributes.solstatus
 
-                # New API first
-                try:
-                    var_vals = model.getSolution([h for _, h in xpress_vars])
-                    vals = var_vals
-                    slacks = (
-                        model.getSlacks([h for _, _, h in xpress_cons])
-                        if xpress_cons
-                        else None
-                    )
-                    duals = (
-                        model.getDuals([h for _, _, h in xpress_cons])
-                        if xpress_cons
-                        else None
-                    )
-                    djs = model.getRedCosts([h for _, h in xpress_vars])
-                except Exception:
-                    # Fallback to deprecated API
-                    try:
-                        x_list, s_list, d_list, rc_list = [], [], [], []
-                        model.getlpsol(x_list, s_list, d_list, rc_list)
-                        vals = x_list if x_list else None
-                        slacks = s_list if s_list else None
-                        duals = d_list if d_list else None
-                        djs = rc_list if rc_list else None
-                    except Exception:
-                        vals = slacks = duals = djs = None
+            # Check if we have a solution (optimal or feasible)
+            if solstatus in [_SS_OPTIMAL, _SS_FEASIBLE]:
+                vals = model.getSolution([h for _, h in xpress_vars])
+                if xpress_cons:
+                    try:  # Try plural version first (Xpress 9.8+)
+                        slacks = model.getSlacks([h for _, _, h in xpress_cons])
+                    except AttributeError:  # Fall back to Xpress 9.7 and earlier
+                        slacks = [model.getSlack(h) for _, _, h in xpress_cons]
+                else:
+                    slacks = None
+
+                # Get dual solution only for LP (not for MIP)
+                if not (_ismip(lp) and self.mip):
+                    if xpress_cons:
+                        try:  # Try plural version first (Xpress 9.8+)
+                            duals = model.getDuals([h for _, _, h in xpress_cons])
+                        except AttributeError:  # Fall back to Xpress 9.7 and earlier
+                            duals = [model.getDual(h) for _, _, h in xpress_cons]
+                    else:
+                        duals = None
+
+                    try:  # Try plural version first (Xpress 9.8+)
+                        djs = model.getRedCosts([h for _, h in xpress_vars])
+                    except AttributeError:  # Fall back to Xpress 9.7 and earlier
+                        djs = [model.getRedCost(h) for _, h in xpress_vars]
 
             # ---- write back into PuLP structures ----
             if vals is not None:
@@ -546,10 +551,11 @@ class XPRESS_PY(LpSolver):
             if slacks is not None:
                 lp.assignConsSlack({n: s for (n, c, _), s in zip(xpress_cons, slacks)})
 
-            status = statusmap.get(
-                model.getAttrib(statuskey), constants.LpStatusUndefined
+            status, sol_status = statusmap.get(
+                solstatus,
+                (constants.LpStatusUndefined, constants.LpSolutionNoSolutionFound),
             )
-            lp.assignStatus(status)
+            lp.assignStatus(status, sol_status)
             return status
 
         except (xpress.ModelError, xpress.InterfaceError, xpress.SolverError) as err:
@@ -633,14 +639,23 @@ class XPRESS_PY(LpSolver):
                         colind.append(v._xprs[0])
                 if _ismip(lp) and self.mip:
                     # If we have a value for every variable then use
-                    # loadmipsol(), which requires a dense solution. Otherwise
-                    # use addmipsol() which allows sparse vectors.
+                    # loadMipSol(), which requires a dense solution. Otherwise
+                    # use addMipSol() which allows sparse vectors.
                     if len(solval) == model.attributes.cols:
-                        model.loadmipsol(solval)
+                        try:  # New API first
+                            model.loadMipSol(solval)
+                        except AttributeError:  # Fallback to deprecated API
+                            model.loadmipsol(solval)
                     else:
-                        model.addmipsol(solval, colind, "warmstart")
+                        try:  # New API first
+                            model.addMipSol(solval, colind, "warmstart")
+                        except AttributeError:  # Fallback to deprecated API
+                            model.addmipsol(solval, colind, "warmstart")
                 else:
-                    model.loadlpsol(solval, None, None, None)
+                    try:  # New API first
+                        model.loadLPSol(solval, None, None, None)
+                    except AttributeError:  # Fallback to deprecated API
+                        model.loadlpsol(solval, None, None, None)
             # Setup message callback if output is requested
             if self.msg:
 
@@ -648,7 +663,10 @@ class XPRESS_PY(LpSolver):
                     if msgtype > 0:
                         print(msg)
 
-                model.addcbmessage(message)
+                try:  # New API first
+                    model.addMessageCallback(message)
+                except AttributeError:  # Fallback to deprecated API
+                    model.addcbmessage(message)
         except (xpress.ModelError, xpress.InterfaceError, xpress.SolverError) as err:
             raise PulpSolverError(str(err))
 
@@ -668,7 +686,10 @@ class XPRESS_PY(LpSolver):
                 rhsind.append(con._xprs[0])
                 rhsval.append(-con.constant)
             if len(rhsind) > 0:
-                lp.solverModel.chgrhs(rhsind, rhsval)
+                try:  # New API first
+                    lp.solverModel.chgRHS(rhsind, rhsval)
+                except AttributeError:  # Fallback to deprecated API
+                    lp.solverModel.chgrhs(rhsind, rhsval)
 
             bndind = list()
             bndtype = list()
@@ -687,7 +708,10 @@ class XPRESS_PY(LpSolver):
                 bndtype.append("G")
                 bndval.append(xpress.infinity if v.upBound is None else v.upBound)
             if len(bndtype) > 0:
-                lp.solverModel.chgbounds(bndind, bndtype, bndval)
+                try:  # New API first
+                    lp.solverModel.chgBounds(bndind, bndtype, bndval)
+                except AttributeError:  # Fallback to deprecated API
+                    lp.solverModel.chgbounds(bndind, bndtype, bndval)
 
             self.callSolver(lp, prepare)
             return self.findSolutionValues(lp)
@@ -750,7 +774,10 @@ class XPRESS_PY(LpSolver):
 
             model = xpress.problem()
             if lp.sense == constants.LpMaximize:
-                model.chgobjsense(xpress.maximize)
+                try:  # New API first
+                    model.chgObjSense(xpress.maximize)
+                except AttributeError:  # Fallback to deprecated API
+                    model.chgobjsense(xpress.maximize)
 
             # Create variables. We first collect the info for all variables
             # and then create all of them in one shot. This is supposed to
@@ -771,7 +798,12 @@ class XPRESS_PY(LpSolver):
                 else:
                     ctype.append("C")
                 names.append(v.name)
-            model.addcols(obj, [0] * (len(obj) + 1), [], [], lb, ub, names, ctype)
+            try:  # New API first
+                model.addCols(obj, [0] * (len(obj) + 1), [], [], lb, ub)
+                model.addNames(xpress.Namespaces.COLUMN, names, 0, len(names) - 1)
+                model.chgColType(range(len(ctype)), ctype)
+            except AttributeError:  # Fallback to deprecated API
+                model.addcols(obj, [0] * (len(obj) + 1), [], [], lb, ub, names, ctype)
             for j, (v, x) in enumerate(zip(lp.variables(), model.getVariable())):
                 v._xprs = (j, x)
 


### PR DESCRIPTION
Modernizes the Xpress solver integration to support the current API (v9.8) while remaining backward compatible with older versions.

### Key Changes
- **XPRESS (CMD):** `available()` now warns if the Xpress Python package is installed but the binary is not found, suggesting `XPRESS_PY` instead
- **XPRESS_PY:** All deprecated lowercase API calls replaced with camelCase equivalents (`optimize`, `lpOptimize`, `writeProb`, `addMessageCallback`, `loadMipSol`, `addMipSol`, `loadLPSol`, `chgRHS`, `chgBounds`, `chgObjSense`, `addCols`) with `AttributeError` fallbacks for older versions
- **XPRESS_PY:** Unified MIP/LP status reporting via `solstatus` attribute with `xpress.SolStatus` enum constants and integer fallbacks
- **Docs:** Added XPRESS and XPRESS_PY solver configuration sections to `how_to_configure_solvers.rst`

### Testing
✅ All 80 XPRESS_PyTest tests passed
✅ Tested with Xpress 9.8
✅ Backward compatible with Xpress 9.0+
