### PR TITLE
Replaced convertions from const cat to rustcore category with internal function.

### DIFF
--- a/pulp/core/_internal.py
+++ b/pulp/core/_internal.py
@@ -28,6 +28,14 @@ def _rust_cat_to_const(rust_cat: _rustcore.Category) -> str:
     return const.LpContinuous
 
 
+def _const_to_rust_cat(const_str: str) -> _rustcore.Category:
+    if const_str == const.LpBinary:
+        return _rustcore.Category.Binary
+    if const_str == const.LpInteger:
+        return _rustcore.Category.Integer
+    return _rustcore.Category.Continuous
+
+
 def _rust_sense_to_const(rsense: _rustcore.Sense) -> int:
     if rsense == _rustcore.Sense.LessEqual:
         return const.LpConstraintLE

--- a/pulp/core/lp_problem.py
+++ b/pulp/core/lp_problem.py
@@ -18,7 +18,7 @@ from .. import mps_lp as mpslp
 from ..apis import LpSolverDefault
 from ..apis.core import LpSolver, clock
 from ..utilities import value
-from ._internal import _const_to_rust_sense, _is_numpy_bool
+from ._internal import _const_to_rust_cat, _const_to_rust_sense, _is_numpy_bool
 from .lp_affine_expression import LpAffineExpression
 from .lp_constraint import LpConstraint
 from .lp_variable import LpVariable
@@ -139,15 +139,7 @@ class LpProblem:
             lb = lowBound
         if upBound is not None and math.isfinite(upBound):
             ub = upBound
-        rcat = (
-            _rustcore.Category.Binary
-            if cat == const.LpBinary
-            else (
-                _rustcore.Category.Integer
-                if cat == const.LpInteger
-                else _rustcore.Category.Continuous
-            )
-        )
+        rcat = _const_to_rust_cat(cat)
         rvar = self._model.add_variable(name, lb, ub, rcat)
         return LpVariable(rvar)
 
@@ -174,15 +166,7 @@ class LpProblem:
         if cat == const.LpBinary:
             lb, ub = 0.0, 1.0
             cat = const.LpInteger
-        rcat = (
-            _rustcore.Category.Binary
-            if cat == const.LpBinary
-            else (
-                _rustcore.Category.Integer
-                if cat == const.LpInteger
-                else _rustcore.Category.Continuous
-            )
-        )
+        rcat = _const_to_rust_cat(cat)
         if len(indices_rest) == 0:
             names = [name % tuple(indexStart + [str(i)]) for i in index]
             vars_ = self._model.add_variables_batch(names, lb, ub, rcat)
@@ -234,15 +218,7 @@ class LpProblem:
         if cat == const.LpBinary:
             lb, ub = 0.0, 1.0
             cat = const.LpInteger
-        rcat = (
-            _rustcore.Category.Binary
-            if cat == const.LpBinary
-            else (
-                _rustcore.Category.Integer
-                if cat == const.LpInteger
-                else _rustcore.Category.Continuous
-            )
-        )
+        rcat = _const_to_rust_cat(cat)
         vars_ = self._model.add_variables_batch(names, lb, ub, rcat)
         return {i: LpVariable(v) for i, v in zip(index, vars_)}
 
@@ -269,15 +245,7 @@ class LpProblem:
         if cat == const.LpBinary:
             lb, ub = 0.0, 1.0
             cat = const.LpInteger
-        rcat = (
-            _rustcore.Category.Binary
-            if cat == const.LpBinary
-            else (
-                _rustcore.Category.Integer
-                if cat == const.LpInteger
-                else _rustcore.Category.Continuous
-            )
-        )
+        rcat = _const_to_rust_cat(cat)
         if len(indices_rest) == 0:
             names = [name % tuple(indexStart + [i]) for i in index]
             vars_ = self._model.add_variables_batch(names, lb, ub, rcat)


### PR DESCRIPTION
Added a _const_to_rust_cat function to the python _internals to replace the repeated nested ternary statements in core/lp_problem.py. No change to functionality.