### PR TITLE
Improve variable category typing

### DIFF
--- a/pulp/core/_internal.py
+++ b/pulp/core/_internal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Literal
 
 from .. import _rustcore
 from .. import constants as const
@@ -18,7 +19,9 @@ def _is_numpy_bool(obj: object) -> bool:
     ).startswith("numpy")
 
 
-def _rust_cat_to_const(rust_cat: _rustcore.Category) -> str:
+def _rust_cat_to_const(
+    rust_cat: _rustcore.Category,
+) -> Literal["Continuous", "Integer"]:
     if rust_cat == _rustcore.Category.Continuous:
         return const.LpContinuous
     if rust_cat == _rustcore.Category.Integer:

--- a/pulp/core/lp_problem.py
+++ b/pulp/core/lp_problem.py
@@ -5,7 +5,7 @@ import math
 import warnings
 from collections.abc import Iterable
 from time import time
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 try:
     import ujson as json  # type: ignore[import-untyped]
@@ -119,7 +119,7 @@ class LpProblem:
         name: str,
         lowBound: float | None = None,
         upBound: float | None = None,
-        cat: str = const.LpContinuous,
+        cat: Literal["Continuous", "Integer", "Binary"] = const.LpContinuous,
     ) -> LpVariable:
         """Add a variable to the problem. Returns LpVariable wrapping the Rust variable."""
         if lowBound is not None and not math.isfinite(lowBound):
@@ -149,7 +149,7 @@ class LpProblem:
         indices: tuple[Iterable[Any], ...] | Iterable[Any] | None = None,
         lowBound: float | None = None,
         upBound: float | None = None,
-        cat: str = const.LpContinuous,
+        cat: Literal["Continuous", "Integer", "Binary"] = const.LpContinuous,
         indexStart: list[Any] | None = None,
     ) -> dict[Any, Any]:
         """Create a dictionary of variables; names built from name + indices."""
@@ -184,7 +184,7 @@ class LpProblem:
         indices: tuple[Iterable[Any], ...] | Iterable[Any] | None,
         lowBound: float | None = None,
         upBound: float | None = None,
-        cat: str = const.LpContinuous,
+        cat: Literal["Continuous", "Integer", "Binary"] = const.LpContinuous,
     ) -> dict[Any, LpVariable]:
         """Create a dictionary of variables with Cartesian product of indices."""
         if not isinstance(indices, tuple):
@@ -228,7 +228,7 @@ class LpProblem:
         indices: tuple[Iterable[Any], ...] | Iterable[Any] | None = None,
         lowBound: float | None = None,
         upBound: float | None = None,
-        cat: str = const.LpContinuous,
+        cat: Literal["Continuous", "Integer", "Binary"] = const.LpContinuous,
         indexStart: list[Any] | None = None,
     ) -> list[Any]:
         """Create a list or nested list of variables; names built from name + indices."""

--- a/pulp/core/lp_variable.py
+++ b/pulp/core/lp_variable.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import math
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from .. import _rustcore
 from .. import mps_lp as mpslp
@@ -168,7 +168,7 @@ class LpVariable:
         self._var.set_ub(float("inf") if value is None else value)
 
     @property
-    def cat(self) -> str:
+    def cat(self) -> Literal["Continuous", "Integer"]:
         return _rust_cat_to_const(self._var.category)
 
     @property

--- a/pulp/mps_lp.py
+++ b/pulp/mps_lp.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, fields
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from . import _rustcore
 from . import constants as const
@@ -65,7 +65,7 @@ class MPSObjective:
 @dataclass
 class MPSVariable:
     name: str
-    cat: str
+    cat: Literal["Continuous", "Integer", "Binary"]
     lowBound: float | None = 0
     upBound: float | None = None
     varValue: float | None = None


### PR DESCRIPTION
Changes the generic `cat: str` to more explicit `Literal["Continuous", "Integer", "Binary"]`. In the getters uses `Literal["Continuous", "Integer"]`, as variables registered as binary are reported as integer with [0,1] bound.

Especially the getter type hint should improve UX. When I was writing some code, I was really confused that the category PuLP reports to me is not the one I passed. With this type hint, at least you will not expect that it will be.