### PR TITLE
feat: add randomSeed argument to COIN_CMD for reproducible CBC solves (#613)

### DIFF
--- a/pulp/apis/coin.py
+++ b/pulp/apis/coin.py
@@ -99,6 +99,7 @@ class COIN_CMD(LpSolver_CMD):
         logPath=None,
         timeMode="elapsed",
         maxNodes=None,
+        randomSeed=None,
     ):
         """
         :param bool mip: if False, assume LP even if integer variables
@@ -117,6 +118,7 @@ class COIN_CMD(LpSolver_CMD):
         :param int strong: number of variables to look at in strong branching (range is 0 to 2147483647)
         :param str timeMode: "elapsed": count wall-time to timeLimit; "cpu": count cpu-time
         :param int maxNodes: max number of nodes during branching. Stops the solving when reached.
+        :param int randomSeed: random seed passed to CBC (``-randomSeed``) for reproducible results
         """
         if warmStart and not keepFiles and operating_system == "win":
             warnings.warn(
@@ -141,6 +143,7 @@ class COIN_CMD(LpSolver_CMD):
             logPath=logPath,
             timeMode=timeMode,
             maxNodes=maxNodes,
+            randomSeed=randomSeed,
         )
 
     def copy(self):
@@ -274,6 +277,7 @@ class COIN_CMD(LpSolver_CMD):
             strong="strong {}",
             timeMode="timeMode {}",
             maxNodes="maxNodes {}",
+            randomSeed="randomSeed {}",
         )
 
         return [

--- a/pulp/tests/test_coin_cmd.py
+++ b/pulp/tests/test_coin_cmd.py
@@ -220,6 +220,44 @@ class COIN_CMD_CBCOptionsTest(BaseSolverTest.PuLPTest):
         )
         self.assertEqual("10", option_value)
 
+    def test_random_seed(self):
+        """
+        Test if setting randomSeed=20 adds randomSeed 20 to the command line.
+        """
+        # randomSeed is a public constructor argument that flows into optionsDict.
+        self.assertEqual(20, solvers.COIN_CMD(randomSeed=20).optionsDict["randomSeed"])
+        name = self._testMethodName
+        prob = LpProblem(name, const.LpMinimize)
+        x = prob.add_variable("x", 0, 4)
+        y = prob.add_variable("y", -1, 1)
+        z = prob.add_variable("z", 0)
+        w = prob.add_variable("w", 0)
+        prob += x + 4 * y + 9 * z, "obj"
+        prob += x + y <= 5, "c1"
+        prob += x + z >= 10, "c2"
+        prob += -y + z == 7, "c3"
+        prob += w >= 0, "c4"
+        logFilename = name + ".log"
+        self.solver.optionsDict["logPath"] = logFilename
+        self.solver.optionsDict["randomSeed"] = 20
+        pulpTestCheck(
+            prob,
+            self.solver,
+            [const.LpStatusOptimal],
+            {x: 4, y: -1, z: 6, w: 0},
+        )
+        if not os.path.exists(logFilename):
+            raise PulpError(f"Test failed for solver: {self.solver}")
+        if not os.path.getsize(logFilename):
+            raise PulpError(f"Test failed for solver: {self.solver}")
+        command_line = COIN_CMD_CBCOptionsTest.read_command_line_from_log_file(
+            logFilename
+        )
+        option_value = COIN_CMD_CBCOptionsTest.extract_option_from_command_line(
+            command_line, option="randomSeed", grp_pattern="\\d+"
+        )
+        self.assertEqual("20", option_value)
+
 
 class COIN_CMDTest(BaseSolverTest.PuLPTest):
     solveInst = solvers.COIN_CMD


### PR DESCRIPTION
## Motivation

`COIN_CMD` already exposes `threads`, `maxNodes`, `timeMode`, `gapRel`, etc. as constructor arguments that translate to CBC command-line options, but the random seed (CBC's `-randomSeed`) could previously only be set through the generic `options` list, e.g. `COIN_CMD(options=["randomSeed 20"])`. Setting the seed is the standard way to make MIP solves reproducible (and can also change solve time), so it is worth exposing directly. This was requested in #613 and seconded there by a contributor.

## Change

- Add a `randomSeed` keyword argument to `COIN_CMD.__init__`. It flows into `optionsDict` like the other options and is emitted as `-randomSeed <n>` from `getOptions`, mirroring the existing `threads` / `maxNodes` handling.
- Note: the issue also mentions `PULP_CBC_CMD`, but that class no longer exists; `COIN_CMD` is the current CBC entry point (and the default solver), so the argument lives there.

## Verification

- Confirmed CBC accepts `-randomSeed <n>` and solves to optimality (against PuLP's CBC binary).
- Confirmed `getOptions()` emits `randomSeed 20` when `randomSeed=20` is set, so `-randomSeed 20` appears on the solver command line.
- Added `test_random_seed` (in `COIN_CMD_CBCOptionsTest`) mirroring the existing `test_strong`: it solves a small MIP with a seed, reads the command line back from the log file, and asserts `-randomSeed 20` is present; it also asserts the constructor argument populates `optionsDict`.

Closes #613.