### PR TITLE
fix: make FSCIP_CMD write the log to logPath

### DIFF
--- a/pulp/apis/scip.py
+++ b/pulp/apis/scip.py
@@ -334,10 +334,10 @@ class FSCIP_CMD(LpSolver_CMD):
         command.append(tmpLp)
         command.extend(["-s", tmpOptions])
         command.extend(["-fsol", tmpSol])
-        if not self.msg:
+        if not self.msg and "logPath" not in self.optionsDict:
+            # fscip's -q suppresses all output, which would also leave the log
+            # file empty, so it is only used when no logPath is given
             command.append("-q")
-        if "logPath" in self.optionsDict:
-            command.extend(["-l", self.optionsDict["logPath"]])
         if "threads" in self.optionsDict:
             command.extend(["-sth", f"{self.optionsDict['threads']}"])
 
@@ -369,7 +369,18 @@ class FSCIP_CMD(LpSolver_CMD):
         with open(tmpParams, "w") as parameters_file:
             parameters_file.write("\n".join(file_parameters))
 
-        pipe = self.get_pipe()
+        # fscip's own -l flag appends the process rank to the log file name
+        # (e.g. fscip.log0), so the log is captured by redirecting the process
+        # output instead, as done by COIN_CMD
+        logPath = self.optionsDict.get("logPath")
+        if logPath:
+            if self.msg:
+                warnings.warn(
+                    "`logPath` argument replaces `msg=1`. The output will be redirected to the log file."
+                )
+            pipe = open(logPath, "w")
+        else:
+            pipe = self.get_pipe()
         subprocess.check_call(command, stdout=pipe, stderr=pipe)
 
         if pipe is not None:

--- a/pulp/tests/test_fscip_cmd.py
+++ b/pulp/tests/test_fscip_cmd.py
@@ -1,5 +1,6 @@
 """Unit tests for fscip_cmd solver."""
 
+import os
 from typing import ClassVar
 
 import pulp.apis as solvers
@@ -47,3 +48,22 @@ class FSCIP_CMDTest(BaseSolverTest.PuLPTest):
         prob += -y + z == 7.5, "c3"
         self.solver.mip = False
         self._apply_pulp_check(prob, sol={x: 3.0, y: -0.5, z: 7})
+
+    def test_fscip_log_path(self):
+        # named differently from test_logPath because its default config is
+        # skipped and PulpTestConfig.merge cannot turn skip=True off
+        prob = LpProblem(self._testMethodName, const.LpMinimize)
+        x = prob.add_variable("x", 0, 4)
+        y = prob.add_variable("y", -1, 1)
+        z = prob.add_variable("z", 0)
+        w = prob.add_variable("w", 0)
+        prob += x + 4 * y + 9 * z, "obj"
+        prob += x + y <= 5, "c1"
+        prob += x + z >= 10, "c2"
+        prob += -y + z == 7, "c3"
+        prob += w >= 0, "c4"
+        self.solver.optionsDict["logPath"] = self._testMethodName + ".log"
+        self._apply_pulp_check(prob, sol={x: 4, y: -1, z: 6, w: 0})
+        log_filename = self._testMethodName + ".log"
+        self.assertTrue(os.path.exists(log_filename))
+        self.assertTrue(os.path.getsize(log_filename))


### PR DESCRIPTION
## What

`FSCIP_CMD(logPath=...)` never wrote a log file, because fscip's own `-l` flag does not behave like scip's. This PR follows the `COIN_CMD` convention instead: the log is captured by redirecting the solver process output to `logPath`.

Fixes #892.

## Root cause

The current code passes the log path to the binary:

```python
if "logPath" in self.optionsDict:
    command.extend(["-l", self.optionsDict["logPath"]])
```

Plain `scip` handles `-l <file>` by copying its screen output to `<file>`. FiberSCIP does not: in UG, every process appends **its rank to the log file name** before opening it in append mode:

- `ug/src/ug_scip/scipParaInitiator.cpp` (LoadCoordinator, rank 0):
  ```cpp
  std::ostringstream os;
  os << logname << paraComm->getRank();
  lognameinstance = os.str();
  ...
  logfile = fopen(lognameinstance.c_str(), "a");
  ```
- `ug/src/ug_scip/scipParaSolver.cpp` (solver threads, ranks 1..N): same pattern.

So `FSCIP_CMD(logPath="fscip.log")` silently creates `fscip.log0` (plus `fscip.log1...N` with `-sth`), and the file the user asked for is never created — exactly what was reported in #892. This is also why ZIB's own test scripts (`check/run_fscip.sh` in scipopt/scip) never use `-l`; they capture fscip output with `| tee -a`.

## The fix

Mirror what `COIN_CMD` already does (`pulp/apis/coin.py`): redirect the process output to the log file and stop passing `-l`.

One extra subtlety: fscip's `-q` flag suppresses *all* output (it is handled inside UG's message handler), so when a `logPath` is requested, `-q` must not be passed or the redirected log would be empty:

```python
if not self.msg and "logPath" not in self.optionsDict:
    command.append("-q")
```

Behavioral notes:
- `logPath` + `msg=True` warns that output is redirected to the log file (same message as `COIN_CMD`).
- Users who want fscip's per-rank log files can still pass them explicitly via `options=["-l", "..."]`.

## Testing

- Added `FSCIP_CMDTest.test_fscip_log_path`, which solves the standard test LP with `logPath` set and asserts the file exists and is non-empty (same assertions as `check_log_path`).
- Since I don't have fscip binaries on Windows, I verified end-to-end with a mock `fscip` executable that implements UG's real CLI contract (writes the log to `<logname>0` under `-l`, produces no output under `-q`, writes the solution file from `-fsol`):
  - before the fix: `log.log` missing, stray `log.log0` created (issue reproduced);
  - after the fix: log written to the exact requested path, no stray files, `msg=True/False` both covered;
  - `test_fscip_log_path` passes against the mock.
- `ruff check pulp`, `ruff format pulp --check` and `ty check pulp` show no new findings.

## Side note (test infra)

While wiring this up I noticed `PulpTestConfig.merge` cannot turn a default `skip=True` into `skip=False` (the `ov is not False` guard falls through to the default), which is why the existing `"test_logPath": PulpTestConfig(skip=False, check_log_path=True)` override in `test_coin_cmd.py` has no effect either. That's why this test uses a distinct name instead of unskipping `test_logPath`. Happy to send a follow-up PR fixing the merge logic if that sounds useful.
